### PR TITLE
Fix time conflict check for letter slots

### DIFF
--- a/nsysu_selector_helper/src/services/courseService.ts
+++ b/nsysu_selector_helper/src/services/courseService.ts
@@ -16,9 +16,9 @@ export class CourseService {
 
       // 檢查兩個時間都存在且不為空字符串
       if (time1 && time2 && time1.trim() !== '' && time2.trim() !== '') {
-        // 清理並只保留數字字符
-        const cleanTime1 = time1.trim().replace(/[^0-9]/g, '');
-        const cleanTime2 = time2.trim().replace(/[^0-9]/g, '');
+        // 清理並只保留數字及 A-F 字符，避免刪除特殊時段代碼
+        const cleanTime1 = time1.trim().replace(/[^0-9A-F]/gi, '');
+        const cleanTime2 = time2.trim().replace(/[^0-9A-F]/gi, '');
 
         if (cleanTime1 && cleanTime2) {
           const timeSlots1 = cleanTime1.split('');


### PR DESCRIPTION
## Summary
- allow A-F time slot codes in time conflict detection

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm run build` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_683fc806bc288326a7e70fc129998509