### PR TITLE
Persist filters using localStorage

### DIFF
--- a/nsysu_selector_helper/src/components/SelectorPanel/AllCourses.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/AllCourses.tsx
@@ -15,7 +15,7 @@ import styled from 'styled-components';
 import { CourseService } from '@/services/courseService';
 import { AdvancedFilterService } from '@/services/advancedFilterService';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
-import { useCourseSorting } from '@/hooks';
+import { useCourseSorting, useFilterPersistence } from '@/hooks';
 import {
   selectCourses,
   selectDisplaySelectedOnly,
@@ -49,6 +49,7 @@ const StyledCard = styled(Card)`
 `;
 
 const AllCourses: React.FC = () => {
+  useFilterPersistence();
   const dispatch = useAppDispatch();
   const courses = useAppSelector(selectCourses);
   const displaySelectedOnly = useAppSelector(selectDisplaySelectedOnly);

--- a/nsysu_selector_helper/src/components/SelectorPanel/AllCourses.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/AllCourses.tsx
@@ -15,7 +15,7 @@ import styled from 'styled-components';
 import { CourseService } from '@/services/courseService';
 import { AdvancedFilterService } from '@/services/advancedFilterService';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
-import { useCourseSorting, useFilterPersistence } from '@/hooks';
+import { useCourseSorting, useFilterPersistence, useSortPersistence } from '@/hooks';
 import {
   selectCourses,
   selectDisplaySelectedOnly,
@@ -50,6 +50,7 @@ const StyledCard = styled(Card)`
 
 const AllCourses: React.FC = () => {
   useFilterPersistence();
+  useSortPersistence();
   const dispatch = useAppDispatch();
   const courses = useAppSelector(selectCourses);
   const displaySelectedOnly = useAppSelector(selectDisplaySelectedOnly);

--- a/nsysu_selector_helper/src/components/SelectorPanel/AllCourses.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/AllCourses.tsx
@@ -15,7 +15,11 @@ import styled from 'styled-components';
 import { CourseService } from '@/services/courseService';
 import { AdvancedFilterService } from '@/services/advancedFilterService';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
-import { useCourseSorting, useFilterPersistence, useSortPersistence } from '@/hooks';
+import {
+  useCourseSorting,
+  useFilterPersistence,
+  useSortPersistence,
+} from '@/hooks';
 import {
   selectCourses,
   selectDisplaySelectedOnly,

--- a/nsysu_selector_helper/src/hooks/index.ts
+++ b/nsysu_selector_helper/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useThemeConfig';
 export * from './useWindowSize';
 export * from './useCustomQuickFilters';
 export * from './useCourseSorting';
+export * from './useFilterPersistence';

--- a/nsysu_selector_helper/src/hooks/index.ts
+++ b/nsysu_selector_helper/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './useWindowSize';
 export * from './useCustomQuickFilters';
 export * from './useCourseSorting';
 export * from './useFilterPersistence';
+export * from './useSortPersistence';

--- a/nsysu_selector_helper/src/hooks/useCourseSorting.ts
+++ b/nsysu_selector_helper/src/hooks/useCourseSorting.ts
@@ -1,31 +1,11 @@
-import { useEffect, useMemo } from 'react';
-import { useAppSelector, useAppDispatch } from '@/store/hooks';
-import { selectSortConfig, setSortConfig } from '@/store';
+import { useMemo } from 'react';
+import { useAppSelector } from '@/store/hooks';
+import { selectSortConfig } from '@/store';
 import { CourseSortingService } from '@/services/courseSortingService';
 import type { Course } from '@/types';
 
 export const useCourseSorting = (courses: Course[]) => {
-  const dispatch = useAppDispatch();
   const sortConfig = useAppSelector(selectSortConfig);
-  // 在組件載入時從 localStorage 載入排序設定
-  useEffect(() => {
-    const savedConfig = CourseSortingService.loadSortConfig();
-    // 比較新舊配置結構是否不同
-    const currentRules = sortConfig.rules || [];
-    const savedRules = savedConfig.rules || [];
-
-    const isDifferent =
-      currentRules.length !== savedRules.length ||
-      currentRules.some(
-        (rule, index) =>
-          rule.option !== savedRules[index]?.option ||
-          rule.direction !== savedRules[index]?.direction,
-      );
-
-    if (isDifferent) {
-      dispatch(setSortConfig(savedConfig));
-    }
-  }, [dispatch, sortConfig]);
 
   // 排序課程
   const sortedCourses = useMemo(() => {

--- a/nsysu_selector_helper/src/hooks/useFilterPersistence.ts
+++ b/nsysu_selector_helper/src/hooks/useFilterPersistence.ts
@@ -33,4 +33,3 @@ export const useFilterPersistence = () => {
     FilterPersistenceService.saveFilters(filterConditions, selectedTimeSlots);
   }, [filterConditions, selectedTimeSlots]);
 };
-

--- a/nsysu_selector_helper/src/hooks/useFilterPersistence.ts
+++ b/nsysu_selector_helper/src/hooks/useFilterPersistence.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import {
+  selectFilterConditions,
+  selectSelectedTimeSlots,
+  setFilterConditions,
+  setSelectedTimeSlots,
+} from '@/store';
+import { FilterPersistenceService } from '@/services';
+
+/**
+ * Sync filter conditions and time slot filters with localStorage
+ */
+export const useFilterPersistence = () => {
+  const dispatch = useAppDispatch();
+  const filterConditions = useAppSelector(selectFilterConditions);
+  const selectedTimeSlots = useAppSelector(selectSelectedTimeSlots);
+
+  // Load saved state on mount
+  useEffect(() => {
+    const { conditions, timeSlots } = FilterPersistenceService.loadFilters();
+    if (conditions.length > 0) {
+      dispatch(setFilterConditions(conditions));
+    }
+    if (timeSlots.length > 0) {
+      dispatch(setSelectedTimeSlots(timeSlots));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Save whenever state changes
+  useEffect(() => {
+    FilterPersistenceService.saveFilters(filterConditions, selectedTimeSlots);
+  }, [filterConditions, selectedTimeSlots]);
+};
+

--- a/nsysu_selector_helper/src/hooks/useSortPersistence.ts
+++ b/nsysu_selector_helper/src/hooks/useSortPersistence.ts
@@ -1,27 +1,15 @@
-import { useEffect, useRef } from 'react';
-import { useAppDispatch, useAppSelector } from '@/store/hooks';
-import { selectSortConfig, setSortConfig } from '@/store';
+import { useEffect } from 'react';
+import { useAppSelector } from '@/store/hooks';
+import { selectSortConfig } from '@/store';
 import { CourseSortingService } from '@/services';
 
 /**
  * Sync sort configuration with localStorage
  */
 export const useSortPersistence = () => {
-  const dispatch = useAppDispatch();
   const sortConfig = useAppSelector(selectSortConfig);
-  const initialized = useRef(false);
 
-  // Load saved sort config on mount
   useEffect(() => {
-    const savedConfig = CourseSortingService.loadSortConfig();
-    dispatch(setSortConfig(savedConfig));
-    initialized.current = true;
-  }, [dispatch]);
-
-  // Save whenever sortConfig changes after initial load
-  useEffect(() => {
-    if (initialized.current) {
-      CourseSortingService.saveSortConfig(sortConfig);
-    }
+    CourseSortingService.saveSortConfig(sortConfig);
   }, [sortConfig]);
 };

--- a/nsysu_selector_helper/src/hooks/useSortPersistence.ts
+++ b/nsysu_selector_helper/src/hooks/useSortPersistence.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { selectSortConfig, setSortConfig } from '@/store';
+import { CourseSortingService } from '@/services';
+
+/**
+ * Sync sort configuration with localStorage
+ */
+export const useSortPersistence = () => {
+  const dispatch = useAppDispatch();
+  const sortConfig = useAppSelector(selectSortConfig);
+  const initialized = useRef(false);
+
+  // Load saved sort config on mount
+  useEffect(() => {
+    const savedConfig = CourseSortingService.loadSortConfig();
+    dispatch(setSortConfig(savedConfig));
+    initialized.current = true;
+  }, [dispatch]);
+
+  // Save whenever sortConfig changes after initial load
+  useEffect(() => {
+    if (initialized.current) {
+      CourseSortingService.saveSortConfig(sortConfig);
+    }
+  }, [sortConfig]);
+};

--- a/nsysu_selector_helper/src/services/__tests__/filterPersistenceService.test.ts
+++ b/nsysu_selector_helper/src/services/__tests__/filterPersistenceService.test.ts
@@ -43,4 +43,3 @@ describe('FilterPersistenceService', () => {
     expect(loaded.timeSlots).toEqual(slots);
   });
 });
-

--- a/nsysu_selector_helper/src/services/__tests__/filterPersistenceService.test.ts
+++ b/nsysu_selector_helper/src/services/__tests__/filterPersistenceService.test.ts
@@ -1,0 +1,46 @@
+import { FilterPersistenceService } from '@/services';
+import type { FilterCondition, TimeSlotFilter } from '@/store/slices/uiSlice';
+
+// Mock localStorage
+const storage: Record<string, string> = {};
+Object.defineProperty(window, 'localStorage', {
+  value: {
+    getItem: jest.fn((k: string) => storage[k] || null),
+    setItem: jest.fn((k: string, v: string) => {
+      storage[k] = v;
+    }),
+    removeItem: jest.fn((k: string) => {
+      delete storage[k];
+    }),
+    clear: jest.fn(() => {
+      Object.keys(storage).forEach((k) => delete storage[k]);
+    }),
+  },
+  writable: true,
+});
+
+describe('FilterPersistenceService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('loads empty arrays when no data stored', () => {
+    const { conditions, timeSlots } = FilterPersistenceService.loadFilters();
+    expect(conditions).toEqual([]);
+    expect(timeSlots).toEqual([]);
+  });
+
+  it('saves and loads filters correctly', () => {
+    const conditions: FilterCondition[] = [
+      { field: 'teacher', type: 'include', value: '張三' },
+    ];
+    const slots: TimeSlotFilter[] = [{ day: 1, timeSlot: '3' }];
+
+    FilterPersistenceService.saveFilters(conditions, slots);
+
+    const loaded = FilterPersistenceService.loadFilters();
+    expect(loaded.conditions).toEqual(conditions);
+    expect(loaded.timeSlots).toEqual(slots);
+  });
+});
+

--- a/nsysu_selector_helper/src/services/filterPersistenceService.ts
+++ b/nsysu_selector_helper/src/services/filterPersistenceService.ts
@@ -39,10 +39,7 @@ export class FilterPersistenceService {
 
   static saveFilterConditions(conditions: FilterCondition[]): void {
     try {
-      localStorage.setItem(
-        FILTER_CONDITIONS_KEY,
-        JSON.stringify(conditions),
-      );
+      localStorage.setItem(FILTER_CONDITIONS_KEY, JSON.stringify(conditions));
     } catch (error) {
       console.error('Failed to save filter conditions:', error);
     }
@@ -65,10 +62,7 @@ export class FilterPersistenceService {
 
   static saveTimeSlotFilters(filters: TimeSlotFilter[]): void {
     try {
-      localStorage.setItem(
-        TIME_SLOT_FILTERS_KEY,
-        JSON.stringify(filters),
-      );
+      localStorage.setItem(TIME_SLOT_FILTERS_KEY, JSON.stringify(filters));
     } catch (error) {
       console.error('Failed to save time slot filters:', error);
     }
@@ -94,4 +88,3 @@ export class FilterPersistenceService {
     return typeof obj.day === 'number' && typeof obj.timeSlot === 'string';
   }
 }
-

--- a/nsysu_selector_helper/src/services/filterPersistenceService.ts
+++ b/nsysu_selector_helper/src/services/filterPersistenceService.ts
@@ -1,0 +1,97 @@
+import type { FilterCondition, TimeSlotFilter } from '@/store/slices/uiSlice';
+
+const FILTER_CONDITIONS_KEY = 'NSYSUCourseSelector.filterConditions';
+const TIME_SLOT_FILTERS_KEY = 'NSYSUCourseSelector.timeSlotFilters';
+
+export class FilterPersistenceService {
+  static loadFilters(): {
+    conditions: FilterCondition[];
+    timeSlots: TimeSlotFilter[];
+  } {
+    return {
+      conditions: this.loadFilterConditions(),
+      timeSlots: this.loadTimeSlotFilters(),
+    };
+  }
+
+  static saveFilters(
+    conditions: FilterCondition[],
+    timeSlots: TimeSlotFilter[],
+  ): void {
+    this.saveFilterConditions(conditions);
+    this.saveTimeSlotFilters(timeSlots);
+  }
+
+  static loadFilterConditions(): FilterCondition[] {
+    try {
+      const stored = localStorage.getItem(FILTER_CONDITIONS_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          return parsed.filter(this.isValidFilterCondition);
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to load filter conditions:', error);
+    }
+    return [];
+  }
+
+  static saveFilterConditions(conditions: FilterCondition[]): void {
+    try {
+      localStorage.setItem(
+        FILTER_CONDITIONS_KEY,
+        JSON.stringify(conditions),
+      );
+    } catch (error) {
+      console.error('Failed to save filter conditions:', error);
+    }
+  }
+
+  static loadTimeSlotFilters(): TimeSlotFilter[] {
+    try {
+      const stored = localStorage.getItem(TIME_SLOT_FILTERS_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          return parsed.filter(this.isValidTimeSlotFilter);
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to load time slot filters:', error);
+    }
+    return [];
+  }
+
+  static saveTimeSlotFilters(filters: TimeSlotFilter[]): void {
+    try {
+      localStorage.setItem(
+        TIME_SLOT_FILTERS_KEY,
+        JSON.stringify(filters),
+      );
+    } catch (error) {
+      console.error('Failed to save time slot filters:', error);
+    }
+  }
+
+  private static isValidFilterCondition(
+    condition: unknown,
+  ): condition is FilterCondition {
+    if (!condition || typeof condition !== 'object') return false;
+    const obj = condition as Record<string, unknown>;
+    return (
+      typeof obj.field === 'string' &&
+      (obj.type === 'include' || obj.type === 'exclude') &&
+      (typeof obj.value === 'string' || Array.isArray(obj.value))
+    );
+  }
+
+  private static isValidTimeSlotFilter(
+    filter: unknown,
+  ): filter is TimeSlotFilter {
+    if (!filter || typeof filter !== 'object') return false;
+    const obj = filter as Record<string, unknown>;
+    return typeof obj.day === 'number' && typeof obj.timeSlot === 'string';
+  }
+}
+

--- a/nsysu_selector_helper/src/services/index.ts
+++ b/nsysu_selector_helper/src/services/index.ts
@@ -2,3 +2,4 @@ export * from './courseService';
 export * from './advancedFilterService';
 export * from './customQuickFiltersService';
 export * from './courseSortingService';
+export * from './filterPersistenceService';

--- a/nsysu_selector_helper/src/store/index.ts
+++ b/nsysu_selector_helper/src/store/index.ts
@@ -25,11 +25,13 @@ export {
   addFilterCondition,
   removeFilterCondition,
   updateFilterCondition,
+  setFilterConditions,
   clearAllFilterConditions, // 時間段篩選相關
   addTimeSlotFilter,
   removeTimeSlotFilter,
   toggleTimeSlotFilter,
   clearAllTimeSlotFilters,
+  setSelectedTimeSlots,
   // 課程排序相關
   setSortConfig,
 } from './slices/uiSlice';

--- a/nsysu_selector_helper/src/store/slices/uiSlice.ts
+++ b/nsysu_selector_helper/src/store/slices/uiSlice.ts
@@ -1,7 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import type { CustomQuickFilter } from '@/services/customQuickFiltersService';
-import { CourseSortingService } from '@/services';
-import type { SortConfig } from '@/services/courseSortingService';
+
+import {
+  CourseSortingService,
+  type CustomQuickFilter,
+  type SortConfig,
+} from '@/services';
 
 // 精確篩選條件類型
 export interface FilterCondition {

--- a/nsysu_selector_helper/src/store/slices/uiSlice.ts
+++ b/nsysu_selector_helper/src/store/slices/uiSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { CustomQuickFilter } from '@/services/customQuickFiltersService';
+import { CourseSortingService } from '@/services';
 import type { SortConfig } from '@/services/courseSortingService';
 
 // 精確篩選條件類型
@@ -57,7 +58,7 @@ const initialState: UIState = {
   showCustomFilterModal: false,
   editingCustomFilter: null,
   // 課程排序相關
-  sortConfig: { rules: [{ option: 'default', direction: 'asc' }] },
+  sortConfig: CourseSortingService.loadSortConfig(),
 };
 
 // Slice

--- a/nsysu_selector_helper/src/store/slices/uiSlice.ts
+++ b/nsysu_selector_helper/src/store/slices/uiSlice.ts
@@ -111,6 +111,9 @@ const uiSlice = createSlice({
     clearAllFilterConditions: (state) => {
       state.filterConditions = [];
     },
+    setFilterConditions: (state, action: PayloadAction<FilterCondition[]>) => {
+      state.filterConditions = action.payload;
+    },
     // 時間段篩選相關
     addTimeSlotFilter: (state, action: PayloadAction<TimeSlotFilter>) => {
       // 檢查是否已經存在相同的時間段篩選
@@ -152,6 +155,9 @@ const uiSlice = createSlice({
     },
     clearAllTimeSlotFilters: (state) => {
       state.selectedTimeSlots = [];
+    },
+    setSelectedTimeSlots: (state, action: PayloadAction<TimeSlotFilter[]>) => {
+      state.selectedTimeSlots = action.payload;
     },
     // 自定義快速篩選器相關
     setCustomQuickFilters: (
@@ -219,11 +225,13 @@ export const {
   removeFilterCondition,
   updateFilterCondition,
   clearAllFilterConditions,
+  setFilterConditions,
   // 時間段篩選相關
   addTimeSlotFilter,
   removeTimeSlotFilter,
   toggleTimeSlotFilter,
   clearAllTimeSlotFilters,
+  setSelectedTimeSlots,
   // 自定義快速篩選器相關
   setCustomQuickFilters,
   addCustomQuickFilter,


### PR DESCRIPTION
## Summary
- add actions to load/save filter data
- persist filter conditions and time slot filters
- provide `useFilterPersistence` hook and integrate in AllCourses
- export new service and hook
- test `FilterPersistenceService`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6845de24bd388326a56f0f782778c67f