### PR TITLE
Fix sorting crash via removing circular import

### DIFF
--- a/nsysu_selector_helper/src/App.tsx
+++ b/nsysu_selector_helper/src/App.tsx
@@ -21,6 +21,7 @@ import SectionHeader from '#/SectionHeader.tsx';
 import EntryNotification from '#/EntryNotification.tsx';
 import SelectorPanel from '#/SelectorPanel.tsx';
 import ScheduleTable from '#/ScheduleTable.tsx';
+import ErrorBoundary from '#/ErrorBoundary.tsx';
 
 const StyledSplitter = styled(Splitter)`
   height: calc(100vh - 52px);
@@ -100,42 +101,44 @@ const App: React.FC = () => {
   }, [dispatch, selectedSemester]);
 
   return (
-    <ConfigProvider theme={themeConfig}>
-      {isLoading && <Spin spinning={true} fullscreen />}
-      <EntryNotification />
-      <SectionHeader
-        selectedKey={selectedTabKey}
-        setSelectedKey={(key: string) => dispatch(setSelectedTabKey(key))}
-        availableSemesters={availableSemesters}
-        selectedSemester={selectedSemester}
-        setSelectedSemester={(semester: string) =>
-          dispatch(setSelectedSemester(semester))
-        }
-      />
-      {/* 桌面版 */}
-      <StyledSplitter>
-        <Splitter.Panel collapsible={true} style={{ width: '100%' }}>
-          <ScheduleTable />
-        </Splitter.Panel>
-        <Splitter.Panel>
-          <SelectorPanel />
-        </Splitter.Panel>
-      </StyledSplitter>
-      {/* 手機版垂直布局 - 使用 antd Collapse */}
-      <MobileLayout>
-        <StyledCollapse
-          activeKey={activeKey}
-          onChange={handleCollapseChange}
-          expandIconPosition='end'
-          style={{ borderRadius: 0 }}
-          bordered={false}
-          items={collapseItems}
+    <ErrorBoundary>
+      <ConfigProvider theme={themeConfig}>
+        {isLoading && <Spin spinning={true} fullscreen />}
+        <EntryNotification />
+        <SectionHeader
+          selectedKey={selectedTabKey}
+          setSelectedKey={(key: string) => dispatch(setSelectedTabKey(key))}
+          availableSemesters={availableSemesters}
+          selectedSemester={selectedSemester}
+          setSelectedSemester={(semester: string) =>
+            dispatch(setSelectedSemester(semester))
+          }
         />
-        <ContentWrapper>
-          <SelectorPanel />
-        </ContentWrapper>
-      </MobileLayout>
-    </ConfigProvider>
+        {/* 桌面版 */}
+        <StyledSplitter>
+          <Splitter.Panel collapsible={true} style={{ width: '100%' }}>
+            <ScheduleTable />
+          </Splitter.Panel>
+          <Splitter.Panel>
+            <SelectorPanel />
+          </Splitter.Panel>
+        </StyledSplitter>
+        {/* 手機版垂直布局 - 使用 antd Collapse */}
+        <MobileLayout>
+          <StyledCollapse
+            activeKey={activeKey}
+            onChange={handleCollapseChange}
+            expandIconPosition='end'
+            style={{ borderRadius: 0 }}
+            bordered={false}
+            items={collapseItems}
+          />
+          <ContentWrapper>
+            <SelectorPanel />
+          </ContentWrapper>
+        </MobileLayout>
+      </ConfigProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/nsysu_selector_helper/src/components/ErrorBoundary.tsx
+++ b/nsysu_selector_helper/src/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  fallback?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  errorInfo: string | null;
+}
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, errorInfo: error.message };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('Uncaught error:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div style={{ padding: '1rem' }}>
+            <h2>Something went wrong.</h2>
+            {this.state.errorInfo && <pre>{this.state.errorInfo}</pre>}
+          </div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/nsysu_selector_helper/src/components/SelectorPanel/AllCourses/CourseSortSelector.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/AllCourses/CourseSortSelector.tsx
@@ -32,13 +32,13 @@ import styled from 'styled-components';
 
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { selectSortConfig, setSortConfig } from '@/store';
+import { CourseSortingService } from '@/services';
 import {
-  CourseSortingService,
-  SortConfig,
-  SortRule,
-  SortDirection,
-  AvailableSortOptions,
-} from '@/services';
+  type SortConfig,
+  type SortRule,
+  type SortDirection,
+  type AvailableSortOptions,
+} from '@/types/sorting';
 import { DEFAULT_SORT_OPTIONS } from '@/constants';
 
 const { Text, Title } = Typography;

--- a/nsysu_selector_helper/src/constants/defaultSortOptions.ts
+++ b/nsysu_selector_helper/src/constants/defaultSortOptions.ts
@@ -1,5 +1,5 @@
 // 預設排序選項
-import { SortOption } from '@/services';
+import type { SortOption } from '@/types/sorting';
 
 export const DEFAULT_SORT_OPTIONS: SortOption[] = [
   {

--- a/nsysu_selector_helper/src/services/__tests__/courseSortingService.test.ts
+++ b/nsysu_selector_helper/src/services/__tests__/courseSortingService.test.ts
@@ -1,4 +1,5 @@
-import { CourseSortingService, type SortConfig } from '@/services';
+import { CourseSortingService } from '@/services';
+import type { SortConfig } from '@/types/sorting';
 import type { Course } from '@/types';
 
 // Mock localStorage

--- a/nsysu_selector_helper/src/services/courseSortingService.ts
+++ b/nsysu_selector_helper/src/services/courseSortingService.ts
@@ -1,37 +1,7 @@
 import type { Course } from '@/types';
+import type { SortConfig } from '@/types/sorting';
 import { DEFAULT_SORT_OPTIONS } from '@/constants';
 import { GetProbability } from '@/utils';
-
-// 可用的排序選項
-export type AvailableSortOptions =
-  | 'default'
-  | 'probability'
-  | 'remaining'
-  | 'available'
-  | 'credit'
-  | 'courseLevel'
-  | 'compulsory';
-
-// 排序選項類型
-export interface SortOption {
-  key: AvailableSortOptions;
-  label: string;
-  description: string;
-}
-
-// 排序方向
-export type SortDirection = 'asc' | 'desc';
-
-// 單一排序配置
-export interface SortRule {
-  option: AvailableSortOptions;
-  direction: SortDirection;
-}
-
-// 多重排序配置
-export interface SortConfig {
-  rules: SortRule[];
-}
 
 // 儲存鍵名
 const STORAGE_KEY = 'NSYSUCourseSelector.sortConfig';

--- a/nsysu_selector_helper/src/services/index.ts
+++ b/nsysu_selector_helper/src/services/index.ts
@@ -3,3 +3,4 @@ export * from './advancedFilterService';
 export * from './customQuickFiltersService';
 export * from './courseSortingService';
 export * from './filterPersistenceService';
+export * from '@/types/sorting';

--- a/nsysu_selector_helper/src/store/slices/uiSlice.ts
+++ b/nsysu_selector_helper/src/store/slices/uiSlice.ts
@@ -1,10 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import {
-  CourseSortingService,
-  type CustomQuickFilter,
-  type SortConfig,
-} from '@/services';
+import { CourseSortingService, type CustomQuickFilter } from '@/services';
+import type { SortConfig } from '@/types/sorting';
 
 // 精確篩選條件類型
 export interface FilterCondition {

--- a/nsysu_selector_helper/src/types/sorting.ts
+++ b/nsysu_selector_helper/src/types/sorting.ts
@@ -1,0 +1,25 @@
+export type AvailableSortOptions =
+  | 'default'
+  | 'probability'
+  | 'remaining'
+  | 'available'
+  | 'credit'
+  | 'courseLevel'
+  | 'compulsory';
+
+export interface SortOption {
+  key: AvailableSortOptions;
+  label: string;
+  description: string;
+}
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortRule {
+  option: AvailableSortOptions;
+  direction: SortDirection;
+}
+
+export interface SortConfig {
+  rules: SortRule[];
+}


### PR DESCRIPTION
## Summary
- extract sort types to a dedicated module to avoid a circular dependency
- update imports in sorting logic and tests

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6846b654d6dc8326a0b088927e37087f