### PR TITLE
Add skeleton placeholder for fast scrolling

### DIFF
--- a/nsysu_selector_helper/src/components/Common/CoursesList.tsx
+++ b/nsysu_selector_helper/src/components/Common/CoursesList.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useMemo } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
-import { Empty } from 'antd';
+import { Empty, Skeleton } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import { CourseService } from '@/services/courseService.ts';
@@ -14,6 +14,12 @@ import {
 import { Course } from '@/types';
 import Header from '#/Common/CoursesList/Header';
 import Item from '#/Common/CoursesList/Item';
+
+const ScrollSeekPlaceholder: React.FC<{ height: number }> = ({ height }) => (
+  <div style={{ height, padding: '8px', boxSizing: 'border-box' }}>
+    <Skeleton active title={false} paragraph={{ rows: 1 }} />
+  </div>
+);
 
 interface CoursesListProps {
   filteredCourses: Course[];
@@ -124,6 +130,11 @@ const CoursesList: React.FC<CoursesListProps> = ({
       data={dataWithHeader}
       itemContent={renderItem}
       topItemCount={1}
+      components={{ ScrollSeekPlaceholder }}
+      scrollSeekConfiguration={{
+        enter: (velocity) => Math.abs(velocity) > 100,
+        exit: (velocity) => Math.abs(velocity) < 30,
+      }}
     />
   );
 };


### PR DESCRIPTION
## Summary
- optimize the virtual course list UX with Ant Design Skeleton when scrolling fast

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846d31d91d48326a6b4957de99c0fb3