### PR TITLE
Add custom course label feature

### DIFF
--- a/nsysu_selector_helper/src/components/Common/CoursesList/Item.tsx
+++ b/nsysu_selector_helper/src/components/Common/CoursesList/Item.tsx
@@ -12,8 +12,13 @@ import {
 } from 'antd';
 
 import type { Course } from '@/types';
-import { useAppDispatch } from '@/store/hooks.ts';
-import { selectCourse, setHoveredCourseId } from '@/store';
+import { useAppDispatch, useAppSelector } from '@/store/hooks.ts';
+import {
+  selectCourseLabels,
+  selectCourseLabelMap,
+  selectCourse,
+  setHoveredCourseId,
+} from '@/store';
 import { useWindowSize } from '@/hooks';
 import { GetProbability } from '@/utils';
 
@@ -142,6 +147,8 @@ const Item: React.FC<ItemProps> = ({
   const { width } = useWindowSize();
   const [isModalVisible, setIsModalVisible] = useState(false);
   const isMobile = width < 768;
+  const labelDefs = useAppSelector(selectCourseLabels);
+  const labelMap = useAppSelector(selectCourseLabelMap);
 
   const handleSelectCourse = (isSelected: boolean) => {
     dispatch(selectCourse({ course, isSelected }));
@@ -272,6 +279,20 @@ const Item: React.FC<ItemProps> = ({
             {tag}
           </StyledTag>
         ))
+    : '';
+  const displayLabels = labelMap[id]
+    ? labelMap[id].map((labelId) => {
+        const def = labelDefs.find((l) => l.id === labelId);
+        if (!def) return null;
+        return (
+          <StyledTag
+            key={labelId}
+            style={{ backgroundColor: def.color, borderColor: def.borderColor }}
+          >
+            {def.name}
+          </StyledTag>
+        );
+      })
     : '';
   return (
     <CourseRow
@@ -405,6 +426,7 @@ const Item: React.FC<ItemProps> = ({
         <CourseInfo>
           <Flex align={'center'} justify={'center'} vertical={true} gap={5}>
             {displayTags}
+            {displayLabels}
           </Flex>
         </CourseInfo>
       </CourseMainRow>

--- a/nsysu_selector_helper/src/components/ScheduleTable.tsx
+++ b/nsysu_selector_helper/src/components/ScheduleTable.tsx
@@ -12,6 +12,8 @@ import {
   selectSelectedCourses,
   selectHoveredCourseId,
   selectSelectedTimeSlots,
+  selectCourseLabels,
+  selectCourseLabelMap,
   setHoveredCourseId,
   setScrollToCourseId,
   setSelectedTabKey,
@@ -304,6 +306,8 @@ const ScheduleTable: React.FC = () => {
   const selectedCourses = useAppSelector(selectSelectedCourses);
   const hoveredCourseId = useAppSelector(selectHoveredCourseId);
   const selectedTimeSlots = useAppSelector(selectSelectedTimeSlots);
+  const labelDefs = useAppSelector(selectCourseLabels);
+  const labelMap = useAppSelector(selectCourseLabelMap);
 
   // Modal state for mobile course details
   const [modalVisible, setModalVisible] = useState(false);
@@ -458,6 +462,7 @@ const ScheduleTable: React.FC = () => {
             const courseWithRoom = {
               ...course,
               roomForThisSlot: roomInfo[dayIndex]?.[slot] || '未知',
+              labels: labelMap[course.id] || [],
             };
             scheduleMap[slot][dayIndex].push(courseWithRoom);
           }
@@ -485,11 +490,17 @@ const ScheduleTable: React.FC = () => {
               const departmentColor = getDepartmentColor(
                 course.department || '其他',
               );
+              const labels = (course as any).labels as string[] | undefined;
+              let displayColor = departmentColor;
+              if (labels && labels.length > 0) {
+                const def = labelDefs.find((l) => l.id === labels[0]);
+                if (def) displayColor = def.color;
+              }
               const isHovered = hoveredCourseId === course.id;
               return (
                 <CourseTag
                   key={`${course.id}-${day}-${slot.key}`}
-                  color={departmentColor}
+                  color={displayColor}
                   $isHovered={isHovered}
                   onClick={(e) => {
                     if (isMobile) {

--- a/nsysu_selector_helper/src/components/SelectorPanel/AllCourses.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/AllCourses.tsx
@@ -62,14 +62,19 @@ const AllCourses: React.FC = () => {
   const searchQuery = useAppSelector(selectSearchQuery);
   const filterConditions = useAppSelector(selectFilterConditions);
   const selectedTimeSlots = useAppSelector(selectSelectedTimeSlots);
+  const labelMap = useAppSelector(selectCourseLabelMap);
 
   // 排序相關狀態
   const [sortSelectorVisible, setSortSelectorVisible] = useState(false);
 
   // 根據搜尋條件、精確篩選條件和時間段篩選條件篩選課程
   const filteredCourses = useMemo(() => {
-    // 先進行基本搜尋
-    let result = CourseService.searchCourses(courses, searchQuery);
+    // 先進行基本搜尋並附加自訂標籤
+    const coursesWithLabels = courses.map((c) => ({
+      ...c,
+      labels: labelMap[c.id] || [],
+    }));
+    let result = CourseService.searchCourses(coursesWithLabels, searchQuery);
 
     // 再進行精確篩選
     if (filterConditions.length > 0) {
@@ -85,7 +90,7 @@ const AllCourses: React.FC = () => {
     }
 
     return result;
-  }, [courses, searchQuery, filterConditions, selectedTimeSlots]);
+  }, [courses, searchQuery, filterConditions, selectedTimeSlots, labelMap]);
 
   // 使用排序 hook
   const { sortedCourses } = useCourseSorting(filteredCourses);

--- a/nsysu_selector_helper/src/services/advancedFilterService.ts
+++ b/nsysu_selector_helper/src/services/advancedFilterService.ts
@@ -74,6 +74,12 @@ export class AdvancedFilterService {
               tag.toLowerCase().includes(normalizedSearchValue),
             );
           }
+          if (condition.field === 'labels') {
+            const labels = (course as any).labels || [];
+            return (labels as string[]).some((tag) =>
+              tag.toLowerCase().includes(normalizedSearchValue),
+            );
+          }
 
           return normalizedCourseValue.includes(normalizedSearchValue);
         });
@@ -109,6 +115,8 @@ export class AdvancedFilterService {
         return course.id;
       case 'tags':
         return course.tags.join(', ');
+      case 'labels':
+        return ((course as any).labels || []).join(', ');
       case 'compulsory':
         return course.compulsory ? '必修' : '選修';
       case 'english':
@@ -216,6 +224,12 @@ export class AdvancedFilterService {
         field: 'tags',
         label: '學程標籤',
         options: this.getTagOptions(courses),
+        searchable: true,
+      },
+      {
+        field: 'labels',
+        label: '自訂標籤',
+        options: this.getLabelOptions(courses),
         searchable: true,
       },
       {
@@ -343,6 +357,26 @@ export class AdvancedFilterService {
   }
 
   /**
+   * 獲取自訂標籤選項
+   */
+  private static getLabelOptions(courses: Course[]): FilterOption[] {
+    const labelCount = new Map<string, number>();
+
+    courses.forEach((course) => {
+      const labels = (course as any).labels as string[] | undefined;
+      labels?.forEach((tag) => {
+        if (tag && tag.trim()) {
+          labelCount.set(tag, (labelCount.get(tag) || 0) + 1);
+        }
+      });
+    });
+
+    return Array.from(labelCount.entries())
+      .map(([value, count]) => ({ value, label: value, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  /**
    * 獲取可用的篩選欄位（簡化版本，用於快速選擇）
    */
   static getAvailableFields(): Array<{ value: string; label: string }> {
@@ -357,6 +391,7 @@ export class AdvancedFilterService {
       { value: 'english', label: '授課語言' },
       { value: 'multipleCompulsory', label: '多選必修' },
       { value: 'tags', label: '學程標籤' },
+      { value: 'labels', label: '自訂標籤' },
       { value: 'room', label: '上課教室' },
       { value: 'id', label: '課程代碼' },
     ];

--- a/nsysu_selector_helper/src/services/courseLabelsService.ts
+++ b/nsysu_selector_helper/src/services/courseLabelsService.ts
@@ -1,0 +1,42 @@
+export interface CourseLabel {
+  id: string;
+  name: string;
+  color: string;
+  borderColor?: string;
+}
+
+interface StoredState {
+  labels: CourseLabel[];
+  courseLabels: Record<string, string[]>;
+}
+
+const STORAGE_KEY = 'NSYSUCourseSelector.courseLabels';
+
+export class CourseLabelsService {
+  static loadState(): StoredState {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as StoredState;
+        if (
+          parsed &&
+          Array.isArray(parsed.labels) &&
+          typeof parsed.courseLabels === 'object'
+        ) {
+          return parsed;
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to load course labels:', error);
+    }
+    return { labels: [], courseLabels: {} };
+  }
+
+  static saveState(state: StoredState): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.error('Failed to save course labels:', error);
+    }
+  }
+}

--- a/nsysu_selector_helper/src/services/index.ts
+++ b/nsysu_selector_helper/src/services/index.ts
@@ -3,3 +3,4 @@ export * from './advancedFilterService';
 export * from './customQuickFiltersService';
 export * from './courseSortingService';
 export * from './filterPersistenceService';
+export * from './courseLabelsService';

--- a/nsysu_selector_helper/src/store/index.ts
+++ b/nsysu_selector_helper/src/store/index.ts
@@ -36,6 +36,14 @@ export {
   setSortConfig,
 } from './slices/uiSlice';
 
+export {
+  addLabel,
+  updateLabel,
+  removeLabel,
+  assignLabel,
+  removeCourseLabel,
+} from './slices/courseLabelsSlice';
+
 // Export selectors
 export {
   selectCourses,
@@ -58,4 +66,6 @@ export {
   selectSelectedTimeSlots,
   // 課程排序相關
   selectSortConfig,
+  selectCourseLabels,
+  selectCourseLabelMap,
 } from './selectors';

--- a/nsysu_selector_helper/src/store/reducers.ts
+++ b/nsysu_selector_helper/src/store/reducers.ts
@@ -1,10 +1,12 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import coursesSlice from './slices/coursesSlice';
 import uiSlice from './slices/uiSlice';
+import courseLabelsSlice from './slices/courseLabelsSlice';
 
 export const rootReducer = combineReducers({
   courses: coursesSlice.reducer,
   ui: uiSlice.reducer,
+  courseLabels: courseLabelsSlice.reducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/nsysu_selector_helper/src/store/selectors.ts
+++ b/nsysu_selector_helper/src/store/selectors.ts
@@ -49,3 +49,9 @@ export const selectEditingCustomFilter = (state: RootState) =>
 
 // Course sorting selectors
 export const selectSortConfig = (state: RootState) => state.ui.sortConfig;
+
+// Course labels selectors
+export const selectCourseLabels = (state: RootState) =>
+  state.courseLabels.labels;
+export const selectCourseLabelMap = (state: RootState) =>
+  state.courseLabels.courseLabels;

--- a/nsysu_selector_helper/src/store/slices/courseLabelsSlice.ts
+++ b/nsysu_selector_helper/src/store/slices/courseLabelsSlice.ts
@@ -1,0 +1,80 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { CourseLabelsService, CourseLabel } from '@/services/courseLabelsService';
+
+export interface CourseLabelsState {
+  labels: CourseLabel[];
+  courseLabels: Record<string, string[]>; // courseId -> label ids
+}
+
+const defaultLabels: CourseLabel[] = [
+  { id: 'candidate', name: '候選中課程', color: '#ffe58f' },
+  { id: 'favorite', name: '我的最愛', color: '#ffadd2' },
+];
+
+const persisted = CourseLabelsService.loadState();
+
+const initialState: CourseLabelsState = {
+  labels: persisted.labels.length > 0 ? persisted.labels : defaultLabels,
+  courseLabels: persisted.courseLabels,
+};
+
+const courseLabelsSlice = createSlice({
+  name: 'courseLabels',
+  initialState,
+  reducers: {
+    addLabel: (state, action: PayloadAction<CourseLabel>) => {
+      state.labels.push(action.payload);
+      CourseLabelsService.saveState(state);
+    },
+    updateLabel: (
+      state,
+      action: PayloadAction<{ id: string; updates: Partial<CourseLabel> }>,
+    ) => {
+      const { id, updates } = action.payload;
+      const index = state.labels.findIndex((l) => l.id === id);
+      if (index !== -1) {
+        state.labels[index] = { ...state.labels[index], ...updates };
+        CourseLabelsService.saveState(state);
+      }
+    },
+    removeLabel: (state, action: PayloadAction<string>) => {
+      state.labels = state.labels.filter((l) => l.id !== action.payload);
+      Object.keys(state.courseLabels).forEach((courseId) => {
+        state.courseLabels[courseId] = state.courseLabels[courseId].filter(
+          (id) => id !== action.payload,
+        );
+      });
+      CourseLabelsService.saveState(state);
+    },
+    assignLabel: (
+      state,
+      action: PayloadAction<{ courseId: string; labelId: string }>,
+    ) => {
+      const { courseId, labelId } = action.payload;
+      const labels = state.courseLabels[courseId] || [];
+      if (!labels.includes(labelId)) {
+        state.courseLabels[courseId] = [...labels, labelId];
+        CourseLabelsService.saveState(state);
+      }
+    },
+    removeCourseLabel: (
+      state,
+      action: PayloadAction<{ courseId: string; labelId: string }>,
+    ) => {
+      const { courseId, labelId } = action.payload;
+      const labels = state.courseLabels[courseId] || [];
+      state.courseLabels[courseId] = labels.filter((id) => id !== labelId);
+      CourseLabelsService.saveState(state);
+    },
+  },
+});
+
+export const {
+  addLabel,
+  updateLabel,
+  removeLabel,
+  assignLabel,
+  removeCourseLabel,
+} = courseLabelsSlice.actions;
+
+export default courseLabelsSlice;


### PR DESCRIPTION
## Summary
- allow adding custom course labels with default options
- export labels via store and integrate label persistence service
- include labels in advanced filtering
- show labels in schedule table and course list

## Testing
- `npx tsc -p nsysu_selector_helper/tsconfig.json --noEmit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847020dc3348326bb9292ecf660ddbc