### PR TITLE
Fix: Update auto-fill script for new selection table

### DIFF
--- a/nsysu_selector_helper/src/components/SelectorPanel/SelectedExport.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/SelectedExport.tsx
@@ -173,7 +173,7 @@ const SelectedExport: React.FC = () => {
       .map((item) => ({
         id: item.course.id,
         value: item.points,
-        isSel: '1', // 1 表示選擇匯出
+        isSel: '+', // '+' 表示加選, '-' 表示退選
       }));
 
     if (exportData.length === 0) {
@@ -190,11 +190,17 @@ const doc = frame.contentDocument || frame.contentWindow.document;
 const exportClass = ${JSON.stringify(exportData, null)};
 
 try {
+    // 逐列填入資料以避免欄位錯位
+    const rows = Array.from(doc.querySelectorAll('tr')).filter(tr => tr.querySelectorAll('input').length >= 2);
     exportClass.forEach((ec, i) => {
-        const inputs = doc.querySelectorAll('input');
-        inputs[2*i].value = ec['id'];
-        inputs[2*i+1].value = ec['value'];
-        doc.querySelectorAll('select')[i].value = ec['isSel'];
+        const row = rows[i];
+        if (!row) return;
+        const sel = row.querySelector('select');
+        const idBox = row.querySelectorAll('input')[0];
+        const valBox = row.querySelectorAll('input')[1];
+        if (sel) sel.value = ec['isSel'];
+        if (idBox) idBox.value = ec['id'];
+        if (valBox) valBox.value = ec['value'];
     });
     console.log('自動填寫: 完成');
 } catch (e) {
@@ -239,7 +245,7 @@ try {
         configs[item.id] = {
           courseId: item.id,
           points: item.value,
-          isExported: item.isSel === '1',
+          isExported: item.isSel === '+',
         };
       });
 

--- a/nsysu_selector_helper/src/types/NSYSUCourseAPI.d.ts
+++ b/nsysu_selector_helper/src/types/NSYSUCourseAPI.d.ts
@@ -76,12 +76,12 @@ export type NSYSUAPIResponse = {
  * 已選課程匯出數據結構
  * @property {string} id - 課程代碼
  * @property {number} value - 點數配置 (0-100)
- * @property {string} isSel - 是否選擇匯出 ("1" 為匯出, "0" 為不匯出)
+ * @property {string} isSel - 加退選狀態 ("+" 為加選, "-" 為退選)
  */
 export type ExportCourseData = {
   id: string;
   value: number;
-  isSel: string;
+  isSel: '+' | '-';
 };
 
 /**


### PR DESCRIPTION
## Summary
- handle per-row filling to prevent offset
- switch `isSel` to '+'/'-' in generated scripts

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68aea6a3ae1c8326a536e374325cd8fb