### PR TITLE
i18n: render localized course name from embedded English (partial #32)

### DIFF
--- a/nsysu_selector_helper/src/App.tsx
+++ b/nsysu_selector_helper/src/App.tsx
@@ -4,6 +4,7 @@ import type { CollapseProps } from 'antd';
 import styled from 'styled-components';
 
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { useTranslation } from '@/hooks';
 import {
   fetchAvailableSemesters,
   fetchCourses,
@@ -77,6 +78,7 @@ const App: React.FC = () => {
 
 // 內部組件，可以使用 theme token
 const AppContent: React.FC = () => {
+  const { t } = useTranslation();
   const themeConfig = useAppSelector(selectThemeConfig);
   const { token } = theme.useToken();
   const dispatch = useAppDispatch();
@@ -152,7 +154,7 @@ const AppContent: React.FC = () => {
   const collapseItems: CollapseProps['items'] = [
     {
       key: 'schedulePanel',
-      label: '課程時間表',
+      label: t('課程時間表'),
       children: (
         <ContentWrapper>
           <ScheduleTable />

--- a/nsysu_selector_helper/src/components/Common/CoursesList/Item.tsx
+++ b/nsysu_selector_helper/src/components/Common/CoursesList/Item.tsx
@@ -33,7 +33,7 @@ import {
 import { LabelEditDrawer } from '#/Common/Labels';
 import LabelEditModal from '#/Common/Labels/LabelEditModal';
 import { useTranslation, useWindowSize } from '@/hooks';
-import { GetProbability } from '@/utils';
+import { GetProbability, getLocalizedCourseName } from '@/utils';
 import { Color } from 'antd/es/color-picker';
 import { CoursesState } from '@/store/slices/coursesSlice';
 import type { TranslationKey } from '@/types';
@@ -219,7 +219,8 @@ const Item: React.FC<ItemProps> = ({
   isHovered,
   displayMode = 'all',
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const displayName = getLocalizedCourseName(course.name, i18n.language);
   const [messageApi, contextHolder] = message.useMessage();
   const dispatch = useAppDispatch();
   const { width } = useWindowSize();
@@ -348,7 +349,6 @@ const Item: React.FC<ItemProps> = ({
 
   const {
     id,
-    name,
     url,
     classTime,
     department,
@@ -547,7 +547,7 @@ const Item: React.FC<ItemProps> = ({
                   }}
                   $isDark={isDarkMode}
                 >
-                  {name.split('\n')[0]}
+                  {displayName}
                 </StyledLink>
                 <CourseCodeContainer>
                   <CourseCodeText
@@ -565,7 +565,7 @@ const Item: React.FC<ItemProps> = ({
                 </CourseCodeContainer>
               </div>
               <Modal
-                title={`${name.split('\n')[0]} (${id})`}
+                title={`${displayName} (${id})`}
                 open={isModalVisible}
                 onCancel={hideModal}
                 footer={null}
@@ -642,7 +642,7 @@ const Item: React.FC<ItemProps> = ({
                 content={content}
                 title={
                   <>
-                    {name.split('\n')[0]} ({id})
+                    {displayName} ({id})
                   </>
                 }
                 trigger={['hover', 'focus']}
@@ -654,7 +654,7 @@ const Item: React.FC<ItemProps> = ({
                   rel='noreferrer'
                   $isDark={isDarkMode}
                 >
-                  {name.split('\n')[0]}
+                  {displayName}
                 </StyledLink>
               </Popover>
               <CourseCodeContainer>

--- a/nsysu_selector_helper/src/components/ScheduleTable.tsx
+++ b/nsysu_selector_helper/src/components/ScheduleTable.tsx
@@ -492,7 +492,7 @@ const ScheduleTable: React.FC = () => {
   const handleCourseClick = (course: Course, roomForThisSlot?: string) => {
     if (isMobile) {
       // 手機端：顯示 Modal
-      handleMobileCourseClick(course, roomForThisSlot || '未知');
+      handleMobileCourseClick(course, roomForThisSlot || t('scheduleTable.unknownRoom'));
     } else {
       // 桌面端：直接導航
       handleCourseNavigate(course.id);
@@ -502,7 +502,7 @@ const ScheduleTable: React.FC = () => {
   // 處理手機版長按課程標籤
   const handleCourseLongPress = (course: Course, roomForThisSlot?: string) => {
     if (isMobile) {
-      handleMobileCourseClick(course, roomForThisSlot || '未知');
+      handleMobileCourseClick(course, roomForThisSlot || t('scheduleTable.unknownRoom'));
     }
   };
 
@@ -637,7 +637,8 @@ const ScheduleTable: React.FC = () => {
             const courseWithRoom = {
               ...course,
               labels: labelMap[course.id] || [],
-              roomForThisSlot: roomInfo[dayIndex]?.[slot] || '未知',
+              roomForThisSlot:
+                roomInfo[dayIndex]?.[slot] || t('scheduleTable.unknownRoom'),
             };
             scheduleMap[slot][dayIndex].push(courseWithRoom);
           }
@@ -753,7 +754,7 @@ const ScheduleTable: React.FC = () => {
                         i18n.language,
                       );
                       if (!isMobile) {
-                        return `${localizedName}\n(${course.roomForThisSlot || '未知'})`;
+                        return `${localizedName}\n(${course.roomForThisSlot || t('scheduleTable.unknownRoom')})`;
                       }
                       const isEnglish = i18n.language
                         .toLowerCase()

--- a/nsysu_selector_helper/src/components/ScheduleTable.tsx
+++ b/nsysu_selector_helper/src/components/ScheduleTable.tsx
@@ -195,6 +195,7 @@ const CourseTag = styled(Tag)<{
   $isHovered?: boolean;
   $isActive?: boolean;
   $isDark: boolean;
+  $isEnglish?: boolean;
 }>`
   width: 100%;
   margin: 1px 0;
@@ -233,9 +234,10 @@ const CourseTag = styled(Tag)<{
   }
 
   @media screen and (max-width: 768px) {
-    font-size: 9px;
+    font-size: ${(props) => (props.$isEnglish ? '7.5px' : '9px')};
     padding: 2px 4px;
     margin: 1px 0;
+    line-height: ${(props) => (props.$isEnglish ? '1.15' : '1.3')};
   }
 `;
 
@@ -681,6 +683,7 @@ const ScheduleTable: React.FC = () => {
                   }
                   $isHovered={isHovered}
                   $isDark={isDark}
+                  $isEnglish={i18n.language.toLowerCase().startsWith('en')}
                   onClick={(e) => {
                     if (isMobile) {
                       // 手機版：阻止事件冒泡，但不執行課程點擊
@@ -752,8 +755,12 @@ const ScheduleTable: React.FC = () => {
                       if (!isMobile) {
                         return `${localizedName}\n(${course.roomForThisSlot || '未知'})`;
                       }
-                      return localizedName.length > 6
-                        ? `${localizedName.substring(0, 6)}...`
+                      const isEnglish = i18n.language
+                        .toLowerCase()
+                        .startsWith('en');
+                      const maxLen = isEnglish ? 14 : 6;
+                      return localizedName.length > maxLen
+                        ? `${localizedName.substring(0, maxLen)}...`
                         : localizedName;
                     })()}
                     <ProbabilityText

--- a/nsysu_selector_helper/src/components/ScheduleTable.tsx
+++ b/nsysu_selector_helper/src/components/ScheduleTable.tsx
@@ -37,7 +37,7 @@ import {
   toggleDayTimeSlots,
   clearAllTimeSlotFilters,
 } from '@/store';
-import { GetProbability } from '@/utils';
+import { GetProbability, getLocalizedCourseName } from '@/utils';
 import { downloadScheduleImage } from '@/services';
 import MobileCourseDetailsModal from '#/ScheduleTable/MobileCourseDetailsModal';
 
@@ -415,7 +415,7 @@ interface ScheduleTableRow {
 }
 
 const ScheduleTable: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { width } = useWindowSize();
   const dispatch = useAppDispatch();
   const isDark = useAppSelector(selectIsDarkMode);
@@ -552,6 +552,7 @@ const ScheduleTable: React.FC = () => {
       await downloadScheduleImage(selectedCourses, {
         isDark,
         title: t('課程時間表'),
+        language: i18n.language,
       });
       message.success(t('scheduleExport.exportSuccess'));
     } catch (error) {
@@ -743,11 +744,18 @@ const ScheduleTable: React.FC = () => {
                     )}
                   />
                   <CourseTagContent>
-                    {!isMobile
-                      ? `${course.name.split('\n')[0]}\n(${course.roomForThisSlot || '未知'})`
-                      : course.name.length > 6
-                        ? `${course.name.substring(0, 6)}...`
-                        : course.name}
+                    {(() => {
+                      const localizedName = getLocalizedCourseName(
+                        course.name,
+                        i18n.language,
+                      );
+                      if (!isMobile) {
+                        return `${localizedName}\n(${course.roomForThisSlot || '未知'})`;
+                      }
+                      return localizedName.length > 6
+                        ? `${localizedName.substring(0, 6)}...`
+                        : localizedName;
+                    })()}
                     <ProbabilityText
                       $status={GetProbability.getProbabilityStatus(
                         course.remaining,

--- a/nsysu_selector_helper/src/components/ScheduleTable/MobileCourseDetailsModal.tsx
+++ b/nsysu_selector_helper/src/components/ScheduleTable/MobileCourseDetailsModal.tsx
@@ -8,7 +8,8 @@ import {
   setSelectedTabKey,
 } from '@/store';
 import { useAppDispatch } from '@/store/hooks';
-import { useWindowSize } from '@/hooks';
+import { useTranslation, useWindowSize } from '@/hooks';
+import { getLocalizedCourseName } from '@/utils';
 import type { Course } from '@/types';
 
 interface MobileCourseDetailsModalProps {
@@ -22,6 +23,7 @@ const MobileCourseDetailsModal: React.FC<MobileCourseDetailsModalProps> = ({
   setModalVisible,
   selectedCourse,
 }) => {
+  const { t, i18n } = useTranslation();
   const dispatch = useAppDispatch();
   const { width } = useWindowSize();
   const isMobile = width <= 768;
@@ -42,12 +44,12 @@ const MobileCourseDetailsModal: React.FC<MobileCourseDetailsModalProps> = ({
 
   return (
     <Modal
-      title='課程詳情'
+      title={t('scheduleTable.mobileDetails.title')}
       open={modalVisible}
       onCancel={() => setModalVisible(false)}
       footer={[
         <Button key='cancel' onClick={() => setModalVisible(false)}>
-          關閉
+          {t('scheduleTable.mobileDetails.close')}
         </Button>,
         <Button
           key='navigate'
@@ -60,7 +62,7 @@ const MobileCourseDetailsModal: React.FC<MobileCourseDetailsModalProps> = ({
             }
           }}
         >
-          查看課程
+          {t('scheduleTable.mobileDetails.viewCourse')}
         </Button>,
       ]}
       centered
@@ -68,27 +70,28 @@ const MobileCourseDetailsModal: React.FC<MobileCourseDetailsModalProps> = ({
       {selectedCourse && (
         <div>
           <div style={{ marginBottom: '12px' }}>
-            <strong>課程名稱：</strong>
-            {selectedCourse.name}
+            <strong>{t('scheduleTable.mobileDetails.name')}：</strong>
+            {getLocalizedCourseName(selectedCourse.name, i18n.language)}
           </div>
           <div style={{ marginBottom: '12px' }}>
-            <strong>授課教師：</strong>
+            <strong>{t('scheduleTable.mobileDetails.teacher')}：</strong>
             {selectedCourse.teacher}
           </div>
           <div style={{ marginBottom: '12px' }}>
-            <strong>課程代號：</strong>
+            <strong>{t('scheduleTable.mobileDetails.courseId')}：</strong>
             {selectedCourse.id}
           </div>
           <div style={{ marginBottom: '12px' }}>
-            <strong>學分數：</strong>
+            <strong>{t('scheduleTable.mobileDetails.credit')}：</strong>
             {selectedCourse.credit}
           </div>
           <div style={{ marginBottom: '12px' }}>
-            <strong>教室：</strong>
-            {selectedCourse.roomForThisSlot || '未知'}
+            <strong>{t('scheduleTable.mobileDetails.room')}：</strong>
+            {selectedCourse.roomForThisSlot ||
+              t('scheduleTable.unknownRoom')}
           </div>
           <div style={{ marginBottom: '12px' }}>
-            <strong>系所：</strong>
+            <strong>{t('scheduleTable.mobileDetails.department')}：</strong>
             {selectedCourse.department}
           </div>
         </div>

--- a/nsysu_selector_helper/src/components/SelectorPanel/SelectedExport/Item.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/SelectedExport/Item.tsx
@@ -28,8 +28,8 @@ import {
 } from '@/store';
 import { LabelEditDrawer } from '#/Common/Labels';
 import LabelEditModal from '#/Common/Labels/LabelEditModal';
-import { useWindowSize } from '@/hooks';
-import { GetProbability } from '@/utils';
+import { useTranslation, useWindowSize } from '@/hooks';
+import { GetProbability, getLocalizedCourseName } from '@/utils';
 import { Color } from 'antd/es/color-picker';
 import { CoursesState } from '@/store/slices/coursesSlice';
 
@@ -159,6 +159,8 @@ type ItemProps = {
 };
 
 const Item: React.FC<ItemProps> = ({ course, isHovered }) => {
+  const { i18n } = useTranslation();
+  const displayName = getLocalizedCourseName(course.name, i18n.language);
   const dispatch = useAppDispatch();
   const { width } = useWindowSize();
   const isDarkMode = useAppSelector(selectIsDarkMode);
@@ -259,7 +261,6 @@ const Item: React.FC<ItemProps> = ({ course, isHovered }) => {
 
   const {
     id,
-    name,
     url,
     department,
     credit,
@@ -410,10 +411,10 @@ const Item: React.FC<ItemProps> = ({ course, isHovered }) => {
                 }}
                 $isDark={isDarkMode}
               >
-                {name.split('\n')[0]}
+                {displayName}
               </StyledLink>
               <Modal
-                title={`${name.split('\n')[0]} (${id})`}
+                title={`${displayName} (${id})`}
                 open={isModalVisible}
                 onCancel={hideModal}
                 footer={null}
@@ -472,7 +473,7 @@ const Item: React.FC<ItemProps> = ({ course, isHovered }) => {
               content={content}
               title={
                 <>
-                  {name.split('\n')[0]} ({id})
+                  {displayName} ({id})
                 </>
               }
               trigger={['hover', 'focus']}
@@ -484,7 +485,7 @@ const Item: React.FC<ItemProps> = ({ course, isHovered }) => {
                 rel='noreferrer'
                 $isDark={isDarkMode}
               >
-                {name.split('\n')[0]}
+                {displayName}
               </StyledLink>
             </Popover>
           )}

--- a/nsysu_selector_helper/src/i18n/locales/en/translation.json
+++ b/nsysu_selector_helper/src/i18n/locales/en/translation.json
@@ -35,7 +35,19 @@
     "cancelSelectAllDay": "Cancel selection for {{day}}",
     "clickToFilter": "Click to filter {{day}} period {{timeSlot}}",
     "filtering": "Filtering",
-    "filteringCount": "Filtering ({{count}})"
+    "filteringCount": "Filtering ({{count}})",
+    "unknownRoom": "Unknown",
+    "mobileDetails": {
+      "title": "Course Details",
+      "close": "Close",
+      "viewCourse": "View Course",
+      "name": "Course Name",
+      "teacher": "Teacher",
+      "courseId": "Course ID",
+      "credit": "Credits",
+      "room": "Room",
+      "department": "Department"
+    }
   },
   "scheduleExport": {
     "export": "Export",

--- a/nsysu_selector_helper/src/i18n/locales/zh-TW/translation.json
+++ b/nsysu_selector_helper/src/i18n/locales/zh-TW/translation.json
@@ -35,7 +35,19 @@
     "cancelSelectAllDay": "取消選擇星期{{day}}全天",
     "clickToFilter": "點擊篩選星期{{day}} 第{{timeSlot}}節課程",
     "filtering": "篩選中",
-    "filteringCount": "篩選中 ({{count}})"
+    "filteringCount": "篩選中 ({{count}})",
+    "unknownRoom": "未知",
+    "mobileDetails": {
+      "title": "課程詳情",
+      "close": "關閉",
+      "viewCourse": "查看課程",
+      "name": "課程名稱",
+      "teacher": "授課教師",
+      "courseId": "課程代號",
+      "credit": "學分數",
+      "room": "教室",
+      "department": "系所"
+    }
   },
   "scheduleExport": {
     "export": "匯出",

--- a/nsysu_selector_helper/src/services/scheduleExportService.ts
+++ b/nsysu_selector_helper/src/services/scheduleExportService.ts
@@ -1,5 +1,6 @@
 import type { Course } from '@/types';
 import { timeSlot } from '@/constants';
+import { getLocalizedCourseName } from '@/utils';
 
 /**
  * Time slot mapping for calendar display
@@ -70,6 +71,7 @@ interface ExportOptions {
   isDark?: boolean;
   scale?: number;
   title?: string;
+  language?: string;
 }
 
 interface MergedCourseBlock {
@@ -237,7 +239,12 @@ export const exportScheduleAsImage = async (
   courses: Course[],
   options: ExportOptions = {},
 ): Promise<Blob> => {
-  const { isDark = false, scale = 2, title = '課程時間表' } = options;
+  const {
+    isDark = false,
+    scale = 2,
+    title = '課程時間表',
+    language = 'zh-TW',
+  } = options;
 
   // Determine if we need weekend columns
   const includeWeekends = hasWeekendCourses(courses);
@@ -475,7 +482,7 @@ export const exportScheduleAsImage = async (
     ctx.textAlign = 'left';
     ctx.textBaseline = 'top';
 
-    const courseName = block.course.name.split('\n')[0];
+    const courseName = getLocalizedCourseName(block.course.name, language);
     const nameLines = wrapText(ctx, courseName, contentWidth);
 
     // Show more lines for taller blocks

--- a/nsysu_selector_helper/src/utils/getLocalizedCourseName.ts
+++ b/nsysu_selector_helper/src/utils/getLocalizedCourseName.ts
@@ -1,0 +1,15 @@
+/**
+ * Course `name` fields from the NSYSU API are shaped as `"中文名稱\nEnglish Name"`.
+ * Pick the part that matches the active language, falling back to the Chinese
+ * half when no English translation is provided.
+ */
+export const getLocalizedCourseName = (
+  name: string,
+  language: string,
+): string => {
+  const [zh, en] = name.split('\n');
+  if (language.toLowerCase().startsWith('en') && en && en.trim() !== '') {
+    return en;
+  }
+  return zh;
+};

--- a/nsysu_selector_helper/src/utils/index.ts
+++ b/nsysu_selector_helper/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { GetProbability } from './getProbability';
 export { getSortRuleDisplayText } from './getSortRuleDisplayText';
+export { getLocalizedCourseName } from './getLocalizedCourseName';


### PR DESCRIPTION
## Summary
Turns out `course.name` from the API is shaped as `中文名稱\nEnglish Name` — the English is already there, we were just always picking `split('\n')[0]`. Adds a small `getLocalizedCourseName(name, language)` helper that returns the English half when the active language starts with `en` (and falls back to the Chinese half when no English is present), then uses it at every display call site.

Call sites updated:
- [Common/CoursesList/Item.tsx](nsysu_selector_helper/src/components/Common/CoursesList/Item.tsx) — 4 occurrences
- [SelectorPanel/SelectedExport/Item.tsx](nsysu_selector_helper/src/components/SelectorPanel/SelectedExport/Item.tsx) — 4 occurrences
- [ScheduleTable.tsx](nsysu_selector_helper/src/components/ScheduleTable.tsx) — schedule cell (both desktop and mobile truncation)
- [scheduleExportService.ts](nsysu_selector_helper/src/services/scheduleExportService.ts) — PNG export; accepts `language` through its existing `ExportOptions`, passed by the caller

## Test plan
- [x] `yarn tsc -b` passes
- [x] `yarn test` passes (113/113)
- [ ] Manual: switch to English — course names in the list, the schedule cells, and the exported PNG should render the English half
- [ ] Manual: courses without an English name still render the Chinese half (no blank cells)

Follows up on #33; further progress on #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)