### PR TITLE
i18n: translate sort panel, label manager, and department section (partial #32)

### DIFF
--- a/nsysu_selector_helper/src/components/Common/Labels/LabelEditDrawer.tsx
+++ b/nsysu_selector_helper/src/components/Common/Labels/LabelEditDrawer.tsx
@@ -35,6 +35,7 @@ import {
 import type { CourseLabel } from '@/services/courseLabelService';
 import { DEFAULT_LABELS } from '@/constants';
 import LabelEditModal from '#/Common/Labels/LabelEditModal';
+import { useTranslation } from '@/hooks';
 
 const { Text } = Typography;
 
@@ -67,6 +68,7 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
   onClose,
   courseId,
 }) => {
+  const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const labels = useAppSelector(selectLabels);
   const currentCourseLabels = useAppSelector((state) =>
@@ -111,7 +113,7 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
   const getDropdownMenuItems = (label: CourseLabel): MenuProps['items'] => [
     {
       key: 'edit',
-      label: '編輯',
+      label: t('quickFilter.edit'),
       icon: <EditOutlined />,
       onClick: () => handleEditLabel(label),
     },
@@ -120,7 +122,7 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
     },
     {
       key: 'delete',
-      label: '刪除',
+      label: t('labels.delete'),
       icon: <DeleteOutlined />,
       danger: true,
       onClick: () => handleDeleteLabel(label.id),
@@ -165,7 +167,7 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
         title={
           <Space>
             <TagOutlined />
-            <span>標籤管理</span>
+            <span>{t('labels.manage')}</span>
           </Space>
         }
         placement='left'
@@ -180,12 +182,12 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
             title={
               <Space>
                 <TagOutlined />
-                <span>標籤應用</span>
+                <span>{t('labels.apply')}</span>
                 <Tooltip
                   title={
                     courseId
-                      ? '點擊標籤即可快速應用到當前課程'
-                      : '請先從課程列表開啟標籤管理'
+                      ? t('labels.applyToCurrentCourseHint')
+                      : t('labels.selectCourseFirstLong')
                   }
                 >
                   <InfoCircleOutlined />
@@ -193,7 +195,7 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
               </Space>
             }
             extra={
-              <Tooltip title='新增標籤'>
+              <Tooltip title={t('labels.newLabel')}>
                 <Button
                   type='text'
                   size='small'
@@ -214,10 +216,12 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
                       key={label.id}
                       title={
                         !courseId
-                          ? '請先選擇課程'
+                          ? t('labels.selectCourseFirst')
                           : isApplied
-                            ? `已應用標籤「${label.name}」`
-                            : `應用標籤「${label.name}」到課程`
+                            ? t('labels.alreadyApplied', { name: label.name })
+                            : t('labels.applyLabelToCourse', {
+                                name: label.name,
+                              })
                       }
                       placement='top'
                     >
@@ -280,14 +284,14 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
             ) : (
               <Empty
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
-                description='尚未建立任何標籤'
+                description={t('labels.noLabelsCreated')}
               >
                 <Button
                   type='primary'
                   icon={<PlusOutlined />}
                   onClick={handleCreateLabel}
                 >
-                  建立第一個標籤
+                  {t('labels.createFirstLabel')}
                 </Button>
               </Empty>
             )}
@@ -299,9 +303,11 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
               title={
                 <Space>
                   <TagOutlined />
-                  <span>當前課程標籤</span>
+                  <span>{t('labels.currentCourseLabels')}</span>
                   <Text type='secondary' style={{ fontSize: '12px' }}>
-                    ({currentCourseLabels.length} 個標籤)
+                    {t('labels.labelCount', {
+                      count: currentCourseLabels.length,
+                    })}
                   </Text>
                 </Space>
               }
@@ -330,7 +336,7 @@ const LabelEditDrawer: React.FC<LabelEditDrawerProps> = ({
               ) : (
                 <Empty
                   image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  description='此課程尚未設定標籤'
+                  description={t('labels.noCourseLabelsSet')}
                 />
               )}
             </Card>

--- a/nsysu_selector_helper/src/components/Common/Labels/LabelEditModal.tsx
+++ b/nsysu_selector_helper/src/components/Common/Labels/LabelEditModal.tsx
@@ -13,6 +13,8 @@ import {
   Space,
 } from 'antd';
 import { DEFAULT_COLOR_PRESETS } from '@/constants';
+import { useTranslation } from '@/hooks';
+import type { TranslationKey } from '@/types';
 
 const LabelEditModal: React.FC<{
   open: boolean;
@@ -29,6 +31,7 @@ const LabelEditModal: React.FC<{
   ) => void;
   mode: 'create' | 'edit';
 }> = ({ open, label, onCancel, onSubmit, mode }) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm();
 
   const handleSubmit = async () => {
@@ -56,12 +59,14 @@ const LabelEditModal: React.FC<{
 
   return (
     <Modal
-      title={mode === 'create' ? '新增標籤' : '編輯標籤'}
+      title={mode === 'create' ? t('labels.newLabel') : t('labels.edit')}
       open={open}
       onOk={handleSubmit}
       onCancel={handleCancel}
-      okText={mode === 'create' ? '新增' : '更新'}
-      cancelText='取消'
+      okText={
+        mode === 'create' ? t('labels.createLabel') : t('labels.updateLabel')
+      }
+      cancelText={t('simpleFilter.cancel')}
       destroyOnHidden
       width={600}
     >
@@ -79,33 +84,38 @@ const LabelEditModal: React.FC<{
       >
         <Form.Item
           name='name'
-          label='標籤名稱'
-          rules={[{ required: true, message: '請輸入標籤名稱' }]}
+          label={t('labels.name')}
+          rules={[{ required: true, message: t('labels.nameRequired') }]}
         >
-          <Input placeholder='請輸入標籤名稱' />
+          <Input placeholder={t('labels.namePlaceholder')} />
         </Form.Item>
 
-        <Divider orientation='left'>顏色設定</Divider>
+        <Divider orientation='left'>{t('labels.colorSettings')}</Divider>
 
-        <Form.Item label='常用顏色組合'>
+        <Form.Item label={t('labels.colorPresets')}>
           <Space size={[4, 4]} wrap>
-            {DEFAULT_COLOR_PRESETS.map((preset) => (
-              <Button
-                key={preset.name}
-                size='small'
-                onClick={() => applyColorPreset(preset)}
-                style={{
-                  backgroundColor: preset.bgColor,
-                  color: preset.textColor,
-                  border: `1px solid ${preset.borderColor}`,
-                  height: 'auto',
-                  padding: '4px 8px',
-                }}
-                title={`應用${preset.name}配色`}
-              >
-                {preset.name}
-              </Button>
-            ))}
+            {DEFAULT_COLOR_PRESETS.map((preset) => {
+              const colorKey =
+                `labels.colors.${preset.nameKey}` as TranslationKey;
+              const displayName = t(colorKey);
+              return (
+                <Button
+                  key={preset.nameKey}
+                  size='small'
+                  onClick={() => applyColorPreset(preset)}
+                  style={{
+                    backgroundColor: preset.bgColor,
+                    color: preset.textColor,
+                    border: `1px solid ${preset.borderColor}`,
+                    height: 'auto',
+                    padding: '4px 8px',
+                  }}
+                  title={t('labels.applyColorPreset', { name: displayName })}
+                >
+                  {displayName}
+                </Button>
+              );
+            })}
           </Space>
         </Form.Item>
 
@@ -113,8 +123,8 @@ const LabelEditModal: React.FC<{
           <Col span={8}>
             <Form.Item
               name='bgColor'
-              label='背景色'
-              rules={[{ required: true, message: '請選擇背景色' }]}
+              label={t('labels.bgColor')}
+              rules={[{ required: true, message: t('labels.bgColorRequired') }]}
             >
               <ColorPicker showText />
             </Form.Item>
@@ -122,8 +132,10 @@ const LabelEditModal: React.FC<{
           <Col span={8}>
             <Form.Item
               name='borderColor'
-              label='邊框色'
-              rules={[{ required: true, message: '請選擇邊框色' }]}
+              label={t('labels.borderColor')}
+              rules={[
+                { required: true, message: t('labels.borderColorRequired') },
+              ]}
             >
               <ColorPicker showText />
             </Form.Item>
@@ -131,8 +143,10 @@ const LabelEditModal: React.FC<{
           <Col span={8}>
             <Form.Item
               name='textColor'
-              label='文字色'
-              rules={[{ required: true, message: '請選擇文字色' }]}
+              label={t('labels.textColor')}
+              rules={[
+                { required: true, message: t('labels.textColorRequired') },
+              ]}
             >
               <ColorPicker showText />
             </Form.Item>

--- a/nsysu_selector_helper/src/components/SelectorPanel/AllCourses/CompactSortButton.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/AllCourses/CompactSortButton.tsx
@@ -9,6 +9,8 @@ import styled from 'styled-components';
 import { useAppSelector } from '@/store/hooks';
 import { selectSortConfig } from '@/store';
 import { DEFAULT_SORT_OPTIONS } from '@/constants';
+import { useTranslation } from '@/hooks';
+import { getSortOptionLabel } from '@/utils';
 
 const SortButton = styled(Button)`
   height: 28px;
@@ -26,12 +28,13 @@ interface CompactSortButtonProps {
 }
 
 const CompactSortButton: React.FC<CompactSortButtonProps> = ({ onClick }) => {
+  const { t } = useTranslation();
   const sortConfig = useAppSelector(selectSortConfig);
 
   // 獲取第一個排序規則作為主要顯示
   const primaryRule = sortConfig.rules?.[0];
   const currentOption = DEFAULT_SORT_OPTIONS.find(
-    (opt: { key: string }) => opt.key === primaryRule?.option,
+    (opt) => opt.key === primaryRule?.option,
   );
 
   const isDefaultSort = primaryRule?.option === 'default';
@@ -44,10 +47,11 @@ const CompactSortButton: React.FC<CompactSortButtonProps> = ({ onClick }) => {
 
   // 顯示排序規則數量（如果有多個）
   const ruleCount = sortConfig.rules?.length || 0;
+  const primaryLabel = currentOption
+    ? getSortOptionLabel(currentOption.key, t)
+    : t('sort.defaultLabel');
   const displayText =
-    ruleCount > 1
-      ? `${currentOption?.label || '預設'} (+${ruleCount - 1})`
-      : currentOption?.label || '預設';
+    ruleCount > 1 ? `${primaryLabel} (+${ruleCount - 1})` : primaryLabel;
 
   return (
     <SortButton

--- a/nsysu_selector_helper/src/components/SelectorPanel/AllCourses/CourseSortSelector.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/AllCourses/CourseSortSelector.tsx
@@ -27,6 +27,7 @@ import { CourseSortingService, SortConfig, SortRule } from '@/services';
 import { DEFAULT_SORT_OPTIONS } from '@/constants';
 import SortRuleItem from './SortRuleItem';
 import { getSortRuleDisplayText } from '@/utils';
+import { useTranslation } from '@/hooks';
 
 const { Text, Title } = Typography;
 
@@ -49,6 +50,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
   visible,
   onClose,
 }) => {
+  const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const currentSortConfig = useAppSelector(selectSortConfig);
   const isDarkMode = useAppSelector(selectIsDarkMode);
@@ -187,7 +189,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
       title={
         <Space>
           <SortAscendingOutlined />
-          <span>自訂課程排序</span>
+          <span>{t('sort.customSortTitle')}</span>
         </Space>
       }
       placement='left'
@@ -198,11 +200,11 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
       width={400}
       extra={
         <Popconfirm
-          title='重置為預設排序'
-          description='這將清除所有自訂排序規則'
+          title={t('sort.resetToDefault')}
+          description={t('sort.resetWarning')}
           onConfirm={handleReset}
-          okText='重置'
-          cancelText='取消'
+          okText={t('sort.resetButton')}
+          cancelText={t('simpleFilter.cancel')}
         >
           <Button
             type='text'
@@ -213,7 +215,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
             }
             size='small'
           >
-            重置
+            {t('sort.resetButton')}
           </Button>
         </Popconfirm>
       }
@@ -228,7 +230,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
         >
           <Text type='secondary' style={{ fontSize: '12px' }}>
             <BulbOutlined style={{ marginRight: '4px' }} />
-            可設定多層排序條件，排序將依照優先級依次執行。變更會即時套用到課程列表中。
+            {t('sort.multiSortHint')}
           </Text>
         </Card>
         {/* 快速排序預設 */}
@@ -236,9 +238,9 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
           size='small'
           title={
             <Space>
-              <Tag color='green'>常用排序</Tag>
+              <Tag color='green'>{t('sort.commonSortTag')}</Tag>
               <Text type='secondary' style={{ fontSize: '11px' }}>
-                點擊添加到當前排序
+                {t('sort.commonSortHint')}
               </Text>
             </Space>
           }
@@ -253,7 +255,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
                 ])
               }
             >
-              <AimOutlined /> 依概率
+              <AimOutlined /> {t('sort.commonSort.byProbability')}
             </Button>
             <Button
               size='small'
@@ -264,7 +266,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
                 ])
               }
             >
-              <BarChartOutlined /> 依剩餘名額
+              <BarChartOutlined /> {t('sort.commonSort.byAvailable')}
             </Button>
             <Button
               size='small'
@@ -275,7 +277,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
                 ])
               }
             >
-              <BookOutlined /> 必修+課程等級
+              <BookOutlined /> {t('sort.commonSort.byCompulsoryAndLevel')}
             </Button>
           </Space>
         </Card>
@@ -287,9 +289,9 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
           block
           disabled={!canAddMore}
         >
-          新增排序條件
+          {t('sort.addCondition')}
           {availableOptions.length > 0 &&
-            `(還可新增 ${availableOptions.length} 個)`}
+            ` ${t('sort.canAddMore', { count: availableOptions.length })}`}
         </Button>
         <Divider style={{ margin: '12px 0' }} />
         {/* 排序規則列表 */}
@@ -297,7 +299,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
         tempConfig.rules[0].option !== 'default' ? (
           <div>
             <Title level={5} style={{ margin: '0 0 12px 0' }}>
-              排序規則列表
+              {t('sort.rulesList')}
             </Title>
             {tempConfig.rules.map((rule, index) => (
               <SortRuleItem
@@ -317,7 +319,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
           <Card size='small'>
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
-              description='使用預設排序（按課程順序）'
+              description={t('sort.defaultSortDescription')}
             />
           </Card>
         )}
@@ -326,7 +328,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
           tempConfig.rules[0].option !== 'default' && (
             <Card
               size='small'
-              title='排序預覽'
+              title={t('sort.preview')}
               style={{
                 background: isDarkMode ? '#1a1a1a' : '#f9f9f9',
               }}
@@ -338,7 +340,7 @@ const CourseSortSelector: React.FC<CourseSortSelectorProps> = ({
               >
                 {tempConfig.rules.map((rule, index) => (
                   <Text key={index} style={{ fontSize: '12px' }}>
-                    {index + 1}. {getSortRuleDisplayText(rule)}
+                    {index + 1}. {getSortRuleDisplayText(rule, t)}
                   </Text>
                 ))}
               </Space>

--- a/nsysu_selector_helper/src/components/SelectorPanel/AllCourses/SortRuleItem.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/AllCourses/SortRuleItem.tsx
@@ -21,7 +21,12 @@ import {
 } from '@ant-design/icons';
 import styled from 'styled-components';
 
-import { getSortRuleDisplayText } from '@/utils';
+import {
+  getSortOptionDescription,
+  getSortOptionLabel,
+  getSortRuleDisplayText,
+} from '@/utils';
+import { useTranslation } from '@/hooks';
 
 const { Text } = Typography;
 
@@ -63,6 +68,7 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
   isFirst,
   isLast,
 }) => {
+  const { t } = useTranslation();
   const currentOption = DEFAULT_SORT_OPTIONS.find(
     (opt) => opt.key === rule.option,
   );
@@ -75,7 +81,7 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
     onUpdate(index, { ...rule, direction });
   };
 
-  const displayText = getSortRuleDisplayText(rule);
+  const displayText = getSortRuleDisplayText(rule, t);
 
   return (
     <StyledCollapse
@@ -87,7 +93,9 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
             <Space>
               <SortAscendingOutlined />
               <Text>{displayText}</Text>
-              <Tag color='blue'>第 {index + 1} 優先</Tag>
+              <Tag color='blue'>
+                {t('sort.priorityTag', { priority: index + 1 })}
+              </Tag>
             </Space>
           ),
           extra: (
@@ -101,7 +109,7 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
                     e.stopPropagation();
                     onMoveUp?.(index);
                   }}
-                  title='提高優先級'
+                  title={t('sort.increasePriority')}
                 />
               )}
               {!isLast && (
@@ -113,7 +121,7 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
                     e.stopPropagation();
                     onMoveDown?.(index);
                   }}
-                  title='降低優先級'
+                  title={t('sort.decreasePriority')}
                 />
               )}
               <Button
@@ -125,7 +133,7 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
                   onRemove(index);
                 }}
                 danger
-                title='刪除此排序'
+                title={t('sort.deleteRule')}
               />
             </Space>
           ),
@@ -146,23 +154,23 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
                         display: 'block',
                       }}
                     >
-                      排序方式：
+                      {t('sort.method')}
                     </Text>
                     <Select
                       style={{ width: '100%' }}
                       value={rule.option}
                       onChange={handleOptionChange}
-                      placeholder='選擇排序方式'
+                      placeholder={t('sort.selectMethod')}
                       options={DEFAULT_SORT_OPTIONS.filter(
                         (opt) => opt.key !== 'default',
                       ).map((option) => ({
                         value: option.key,
-                        label: option.label,
+                        label: getSortOptionLabel(option.key, t),
                       }))}
                     />
-                    {currentOption?.description &&
-                      currentOption?.description
-                        .split('；')
+                    {currentOption &&
+                      getSortOptionDescription(currentOption.key, t)
+                        .split(/[；;]\s*/)
                         .map((desc, idx) => (
                           <Text
                             key={idx}
@@ -187,7 +195,7 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
                         display: 'block',
                       }}
                     >
-                      排序方向：
+                      {t('sort.direction')}
                     </Text>
                     <Radio.Group
                       value={rule.direction}
@@ -195,10 +203,10 @@ const SortRuleItem: React.FC<SortRuleItemProps> = ({
                       size='small'
                     >
                       <Radio.Button value='asc'>
-                        <SortAscendingOutlined /> 升序
+                        <SortAscendingOutlined /> {t('sort.ascending')}
                       </Radio.Button>
                       <Radio.Button value='desc'>
-                        <SortDescendingOutlined /> 降序
+                        <SortDescendingOutlined /> {t('sort.descending')}
                       </Radio.Button>
                     </Radio.Group>
                   </div>

--- a/nsysu_selector_helper/src/components/SelectorPanel/DepartmentCourses.tsx
+++ b/nsysu_selector_helper/src/components/SelectorPanel/DepartmentCourses.tsx
@@ -25,6 +25,7 @@ import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import {
   useCourseSorting,
   useDepartmentCoursesFilterPersistence,
+  useTranslation,
 } from '@/hooks';
 import {
   selectCourses,
@@ -105,6 +106,7 @@ const ActionButtonsContainer = styled(Flex)`
 
 const DepartmentCourses: React.FC = () => {
   useDepartmentCoursesFilterPersistence();
+  const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const courses = useAppSelector(selectCourses);
   const selectedCourses = useAppSelector(selectSelectedCourses);
@@ -128,19 +130,30 @@ const DepartmentCourses: React.FC = () => {
 
   const gradeOptions = useMemo(() => {
     return DepartmentCourseService.extractGrades(courses).map((grade) => ({
-      label: grade === '0' ? '不分年級' : `${grade}年級`,
+      label:
+        grade === '0' ? t('department.allGrades') : t('department.gradeLabel', { grade }),
       value: grade,
     }));
-  }, [courses]);
+  }, [courses, t]);
 
   const classOptions = useMemo(() => {
     return DepartmentCourseService.extractClasses(courses).map((cls) => ({
-      label: cls || '不分班',
+      label: cls || t('department.allClasses'),
       value: cls || '',
     }));
-  }, [courses]);
-  const compulsoryTypeOptions =
-    DepartmentCourseService.getCompulsoryTypeOptions();
+  }, [courses, t]);
+  // 必修類型的翻譯對照（value 固定，label 依語系切換）
+  const COMPULSORY_TYPE_LABELS: Record<string, string> = {
+    compulsory: t('department.typeCompulsory'),
+    elective: t('department.typeElective'),
+    multipleCompulsory: t('department.typeMultipleCompulsory'),
+  };
+  const compulsoryTypeOptions = DepartmentCourseService
+    .getCompulsoryTypeOptions()
+    .map((opt) => ({
+      ...opt,
+      label: COMPULSORY_TYPE_LABELS[opt.value] ?? opt.label,
+    }));
 
   // 根據篩選條件過濾課程
   const filteredCourses = useMemo(() => {
@@ -173,31 +186,37 @@ const DepartmentCourses: React.FC = () => {
     );
 
     if (unselectedCourses.length === 0) {
-      void messageApi.info('當前篩選結果中的課程都已被選擇');
+      void messageApi.info(t('department.allCoursesAlreadySelected'));
       return;
     }
 
     if (unselectedCourses.length > 50) {
       modalApi.error({
-        title: '批量選課限制',
-        content: `為防止載入過多課程造成瀏覽器崩潰，單次選擇課程數量不能超過 50 門。請縮小篩選條件或手動選擇課程。`,
-        okText: '確定',
+        title: t('department.batchSelectLimit'),
+        content: t('department.batchSelectLimitExceeded'),
+        okText: t('department.confirm'),
       });
       return;
     }
 
     if (unselectedCourses.length > 20) {
       modalApi.confirm({
-        title: '批量選課確認',
-        content: `您即將選擇 ${unselectedCourses.length} 門課程，這可能會造成大量時間衝突。確定要繼續嗎？`,
+        title: t('department.confirmBatchSelect'),
+        content: t('department.batchSelectWarning', {
+          count: unselectedCourses.length,
+        }),
         onOk: () => {
           unselectedCourses.forEach((course) => {
             dispatch(selectCourse({ course, isSelected: true }));
           });
-          void messageApi.success(`已選擇 ${unselectedCourses.length} 門課程`);
+          void messageApi.success(
+            t('department.coursesSelected', {
+              count: unselectedCourses.length,
+            }),
+          );
         },
-        okText: '確定',
-        cancelText: '取消',
+        okText: t('department.confirm'),
+        cancelText: t('simpleFilter.cancel'),
       });
       return;
     }
@@ -205,7 +224,9 @@ const DepartmentCourses: React.FC = () => {
     unselectedCourses.forEach((course) => {
       dispatch(selectCourse({ course, isSelected: true }));
     });
-    void messageApi.success(`已選擇 ${unselectedCourses.length} 門課程`);
+    void messageApi.success(
+      t('department.coursesSelected', { count: unselectedCourses.length }),
+    );
   };
   // 處理清空當前篩選結果中的已選課程
   const handleClearSelectedCourses = () => {
@@ -215,23 +236,27 @@ const DepartmentCourses: React.FC = () => {
     );
 
     if (selectedCoursesInFilter.length === 0) {
-      void messageApi.info('當前篩選結果中沒有已選課程');
+      void messageApi.info(t('department.noSelectedCoursesInFilter'));
       return;
     }
 
     modalApi.confirm({
-      title: '清除篩選結果中的已選課程',
-      content: `確定要清除當前篩選結果中的 ${selectedCoursesInFilter.length} 門已選課程嗎？`,
+      title: t('department.clearSelectedCourses'),
+      content: t('department.clearSelectedWarning', {
+        count: selectedCoursesInFilter.length,
+      }),
       onOk: () => {
         selectedCoursesInFilter.forEach((course) => {
           dispatch(selectCourse({ course, isSelected: false }));
         });
         void messageApi.success(
-          `已清除 ${selectedCoursesInFilter.length} 門已選課程`,
+          t('department.coursesCleared', {
+            count: selectedCoursesInFilter.length,
+          }),
         );
       },
-      okText: '確定',
-      cancelText: '取消',
+      okText: t('department.confirm'),
+      cancelText: t('simpleFilter.cancel'),
     });
   };
 
@@ -253,7 +278,7 @@ const DepartmentCourses: React.FC = () => {
       >
         <Typography.Title level={5} style={{ margin: 0, marginBottom: 6 }}>
           <ApartmentOutlined style={{ marginRight: 8 }} />
-          系所必/選修
+          {t('department.title')}
         </Typography.Title>
         {/* 操作按鈕 */}
         <ActionButtonsContainer gap={6} justify='space-between' align='center'>
@@ -264,7 +289,9 @@ const DepartmentCourses: React.FC = () => {
             onClick={handleSelectAll}
             disabled={sortedCourses.length === 0 || isEmptyFilter}
           >
-            {isEmptyFilter ? '請先篩選條件' : `全選 (${sortedCourses.length})`}
+            {isEmptyFilter
+              ? t('department.selectFilterFirst')
+              : t('department.selectAll', { count: sortedCourses.length })}
           </Button>
           <Button
             danger
@@ -273,7 +300,9 @@ const DepartmentCourses: React.FC = () => {
             onClick={handleClearSelectedCourses}
             disabled={selectedCoursesInFilterCount === 0}
           >
-            清除已選 ({selectedCoursesInFilterCount})
+            {t('department.clearSelected', {
+              count: selectedCoursesInFilterCount,
+            })}
           </Button>
         </ActionButtonsContainer>
       </Flex>
@@ -283,11 +312,11 @@ const DepartmentCourses: React.FC = () => {
           <FilterRow>
             <FilterLabel>
               <ApartmentOutlined />
-              系所：
+              {t('department.department')}
             </FilterLabel>
             <StyledSelect
               mode='multiple'
-              placeholder='選擇系所'
+              placeholder={t('department.selectDepartment')}
               options={departmentOptions}
               value={departmentFilters.selectedDepartments}
               onChange={(value) =>
@@ -308,11 +337,11 @@ const DepartmentCourses: React.FC = () => {
           <FilterRow>
             <FilterLabel>
               <UserOutlined />
-              年級：
+              {t('department.grade')}
             </FilterLabel>
             <StyledSelect
               mode='multiple'
-              placeholder='選擇年級'
+              placeholder={t('department.selectGrade')}
               options={gradeOptions}
               value={departmentFilters.selectedGrades}
               onChange={(value) =>
@@ -325,11 +354,11 @@ const DepartmentCourses: React.FC = () => {
           <FilterRow>
             <FilterLabel>
               <TeamOutlined />
-              班別：
+              {t('department.class')}
             </FilterLabel>
             <StyledSelect
               mode='multiple'
-              placeholder='選擇班別'
+              placeholder={t('department.selectClass')}
               options={classOptions}
               value={departmentFilters.selectedClasses}
               onChange={(value) =>
@@ -342,11 +371,11 @@ const DepartmentCourses: React.FC = () => {
           <FilterRow>
             <FilterLabel>
               <BookOutlined />
-              類型：
+              {t('department.type')}
             </FilterLabel>
             <StyledSelect
               mode='multiple'
-              placeholder='選擇課程類型'
+              placeholder={t('department.selectType')}
               options={compulsoryTypeOptions}
               value={departmentFilters.selectedCompulsoryTypes}
               onChange={(value) =>
@@ -367,7 +396,7 @@ const DepartmentCourses: React.FC = () => {
         <Space>
           <Space size={2}>
             <Typography.Text style={{ fontSize: '11px' }}>
-              僅顯示已選：
+              {t('allCourse.showSelectedOnly')}
             </Typography.Text>
             <Switch
               checked={displaySelectedOnly}
@@ -377,7 +406,7 @@ const DepartmentCourses: React.FC = () => {
           </Space>
           <Space size={2}>
             <Typography.Text style={{ fontSize: '11px' }}>
-              顯示衝突：
+              {t('allCourse.showConflicts')}
             </Typography.Text>
             <Switch
               checked={displayConflictCourses}

--- a/nsysu_selector_helper/src/constants/defaultColorPresets.ts
+++ b/nsysu_selector_helper/src/constants/defaultColorPresets.ts
@@ -1,48 +1,67 @@
-export const DEFAULT_COLOR_PRESETS = [
+// `nameKey` identifies the preset; display name is resolved via
+// `labels.colors.<nameKey>` at render time.
+export type ColorPresetKey =
+  | 'blue'
+  | 'green'
+  | 'orange'
+  | 'red'
+  | 'purple'
+  | 'cyan'
+  | 'yellow'
+  | 'pink';
+
+export interface ColorPreset {
+  nameKey: ColorPresetKey;
+  bgColor: string;
+  borderColor: string;
+  textColor: string;
+}
+
+export const DEFAULT_COLOR_PRESETS: ColorPreset[] = [
   {
-    name: '藍色',
+    nameKey: 'blue',
     bgColor: '#f0f5ff',
     borderColor: '#adc6ff',
     textColor: '#1890ff',
   },
   {
-    name: '綠色',
+    nameKey: 'green',
     bgColor: '#f6ffed',
     borderColor: '#b7eb8f',
     textColor: '#52c41a',
   },
   {
-    name: '橙色',
+    nameKey: 'orange',
     bgColor: '#fff7e6',
     borderColor: '#ffd591',
     textColor: '#fa8c16',
   },
   {
-    name: '紅色',
+    nameKey: 'red',
     bgColor: '#fff1f0',
     borderColor: '#ffccc7',
     textColor: '#f5222d',
   },
   {
-    name: '紫色',
+    nameKey: 'purple',
     bgColor: '#f9f0ff',
     borderColor: '#d3adf7',
     textColor: '#722ed1',
   },
   {
-    name: '青色',
+    nameKey: 'cyan',
     bgColor: '#e6fffb',
     borderColor: '#87e8de',
     textColor: '#13c2c2',
   },
   {
-    name: '黃色',
+    nameKey: 'yellow',
     bgColor: '#fffbe6',
     borderColor: '#ffe58f',
     textColor: '#d48806',
   },
   {
-    name: '粉色',
+    nameKey: 'pink',
     bgColor: '#fff0f6',
     borderColor: '#ffadd2',
     textColor: '#eb2f96',

--- a/nsysu_selector_helper/src/constants/defaultSortOptions.ts
+++ b/nsysu_selector_helper/src/constants/defaultSortOptions.ts
@@ -1,43 +1,14 @@
 // 預設排序選項
+// `label` / `description` fields intentionally hold the sort key; consumers
+// resolve them through `getSortOptionLabel` / `getSortOptionDescription`.
 import { SortOption } from '@/services';
 
 export const DEFAULT_SORT_OPTIONS: SortOption[] = [
-  {
-    key: 'default',
-    label: '預設順序',
-    description: '系統原始排序（無升序降序）',
-  },
-  {
-    key: 'probability',
-    label: '選上概率',
-    description: '升序：一般概率(低到高)；降序：一般概率(高到低)',
-  },
-  {
-    key: 'remaining',
-    label: '剩餘名額',
-    description:
-      '升序：負數(超收)→0→正數(剩餘名額少到多)；降序：正數(剩餘名額多到少)→0→負數(超收)',
-  },
-  {
-    key: 'available',
-    label: '可選人數',
-    description:
-      '升序：負數(超收)→0→正數(可選名額少到多)；降序：正數(可選名額多到少)→0→負數(超收)',
-  },
-  {
-    key: 'credit',
-    label: '學分數',
-    description: '升序：學分少到多(1→2→3→...)；降序：學分多到少(...→3→2→1)',
-  },
-  {
-    key: 'courseLevel',
-    label: '課程等級',
-    description:
-      '升序：大學部→碩士班→碩士專班→博士班；降序：博士班→碩士專班→碩士班→大學部',
-  },
-  {
-    key: 'compulsory',
-    label: '必修優先',
-    description: '升序：必修課程→選修課程；降序：選修課程→必修課程',
-  },
+  { key: 'default', label: 'default', description: 'default' },
+  { key: 'probability', label: 'probability', description: 'probability' },
+  { key: 'remaining', label: 'remaining', description: 'remaining' },
+  { key: 'available', label: 'available', description: 'available' },
+  { key: 'credit', label: 'credit', description: 'credit' },
+  { key: 'courseLevel', label: 'courseLevel', description: 'courseLevel' },
+  { key: 'compulsory', label: 'compulsory', description: 'compulsory' },
 ];

--- a/nsysu_selector_helper/src/i18n/locales/en/translation.json
+++ b/nsysu_selector_helper/src/i18n/locales/en/translation.json
@@ -243,6 +243,97 @@
     "addButton": "Add Custom Filter",
     "saveCurrentButton": "Save Current Filter"
   },
+  "sort": {
+    "customSortTitle": "Custom Course Sort",
+    "resetToDefault": "Reset to default sort",
+    "resetWarning": "This will clear all custom sort rules.",
+    "resetButton": "Reset",
+    "multiSortHint": "Set up multi-level sort rules. Sorting follows rule priority; changes apply to the course list immediately.",
+    "commonSortTag": "Common sorts",
+    "commonSortHint": "Click to add to current sort",
+    "commonSort": {
+      "byProbability": "By probability",
+      "byAvailable": "By remaining",
+      "byCompulsoryAndLevel": "Required + level"
+    },
+    "addCondition": "Add sort rule",
+    "canAddMore": "({{count}} more available)",
+    "rulesList": "Sort rules",
+    "defaultSortDescription": "Using default sort (by course order)",
+    "preview": "Sort preview",
+    "priorityTag": "Priority {{priority}}",
+    "increasePriority": "Increase priority",
+    "decreasePriority": "Decrease priority",
+    "deleteRule": "Delete this rule",
+    "method": "Sort by:",
+    "selectMethod": "Choose a sort method",
+    "direction": "Direction:",
+    "ascending": "Ascending",
+    "descending": "Descending",
+    "defaultLabel": "Default",
+    "defaultSort": "Default sort",
+    "options": {
+      "default": {
+        "label": "Default order",
+        "description": "System's original order (no ascending/descending)"
+      },
+      "probability": {
+        "label": "Selection probability",
+        "description": "Asc: probability low → high; Desc: probability high → low"
+      },
+      "remaining": {
+        "label": "Remaining seats",
+        "description": "Asc: negative (over) → 0 → positive (few → many); Desc: positive (many → few) → 0 → negative (over)"
+      },
+      "available": {
+        "label": "Available seats",
+        "description": "Asc: negative (over) → 0 → positive (few → many); Desc: positive (many → few) → 0 → negative (over)"
+      },
+      "credit": {
+        "label": "Credits",
+        "description": "Asc: credits low → high (1→2→3→...); Desc: credits high → low (...→3→2→1)"
+      },
+      "courseLevel": {
+        "label": "Course level",
+        "description": "Asc: Undergrad → Master → Master (EMBA) → PhD; Desc: PhD → Master (EMBA) → Master → Undergrad"
+      },
+      "compulsory": {
+        "label": "Required first",
+        "description": "Asc: required → elective; Desc: elective → required"
+      }
+    }
+  },
+  "department": {
+    "title": "Department courses",
+    "allGrades": "All grades",
+    "gradeLabel": "Grade {{grade}}",
+    "allClasses": "All classes",
+    "department": "Department:",
+    "selectDepartment": "Select department",
+    "grade": "Grade:",
+    "selectGrade": "Select grade",
+    "class": "Class:",
+    "selectClass": "Select class",
+    "type": "Type:",
+    "selectType": "Select course type",
+    "selectAll": "Select all ({{count}})",
+    "selectFilterFirst": "Apply a filter first",
+    "clearSelected": "Clear selected ({{count}})",
+    "allCoursesAlreadySelected": "All courses in the current filter are already selected.",
+    "batchSelectLimit": "Bulk selection limit",
+    "batchSelectLimitExceeded": "To prevent browser crashes from loading too many courses, you can't select more than 50 at once. Narrow the filter or select courses manually.",
+    "confirmBatchSelect": "Confirm bulk selection",
+    "batchSelectWarning": "You're about to select {{count}} courses. This may cause many time conflicts. Continue?",
+    "coursesSelected": "Selected {{count}} courses",
+    "noSelectedCoursesInFilter": "No selected courses in the current filter.",
+    "clearSelectedCourses": "Clear selected courses in filter",
+    "clearSelectedWarning": "Clear {{count}} selected courses from the current filter?",
+    "coursesCleared": "Cleared {{count}} selected courses",
+    "confirm": "OK",
+    "typeCompulsory": "Required courses",
+    "typeElective": "Elective courses",
+    "typeMultipleCompulsory": "Multi-select required"
+  },
   "simpleFilter": {
     "title": "Simple Filter",
     "simpleMode": "Simple Mode",
@@ -294,9 +385,42 @@
     "edit": "Edit Labels",
     "newLabel": "New Label",
     "name": "Label Name",
-
     "bgColor": "Background Color",
-    "borderColor": "Border Color"
+    "borderColor": "Border Color",
+    "textColor": "Text Color",
+    "nameRequired": "Please enter a label name",
+    "namePlaceholder": "Enter a label name",
+    "bgColorRequired": "Please pick a background color",
+    "borderColorRequired": "Please pick a border color",
+    "textColorRequired": "Please pick a text color",
+    "colorSettings": "Color settings",
+    "colorPresets": "Color presets",
+    "applyColorPreset": "Apply {{name}} colors",
+    "createLabel": "Create",
+    "updateLabel": "Update",
+    "delete": "Delete",
+    "manage": "Label Manager",
+    "apply": "Apply labels",
+    "applyToCurrentCourseHint": "Click a label to apply it to the current course",
+    "selectCourseFirstLong": "Open label management from the course list first",
+    "selectCourseFirst": "Select a course first",
+    "alreadyApplied": "Label \"{{name}}\" already applied",
+    "applyLabelToCourse": "Apply label \"{{name}}\" to course",
+    "noLabelsCreated": "No labels created yet",
+    "createFirstLabel": "Create your first label",
+    "currentCourseLabels": "Current course labels",
+    "labelCount": "({{count}} labels)",
+    "noCourseLabelsSet": "No labels set for this course",
+    "colors": {
+      "blue": "Blue",
+      "green": "Green",
+      "orange": "Orange",
+      "red": "Red",
+      "purple": "Purple",
+      "cyan": "Cyan",
+      "yellow": "Yellow",
+      "pink": "Pink"
+    }
   },
   "selectedExport": {
     "title": "Selected Export",

--- a/nsysu_selector_helper/src/i18n/locales/zh-TW/translation.json
+++ b/nsysu_selector_helper/src/i18n/locales/zh-TW/translation.json
@@ -243,6 +243,97 @@
     "addButton": "新增自定義篩選器",
     "saveCurrentButton": "保存目前篩選條件"
   },
+  "sort": {
+    "customSortTitle": "自訂課程排序",
+    "resetToDefault": "重置為預設排序",
+    "resetWarning": "這將清除所有自訂排序規則",
+    "resetButton": "重置",
+    "multiSortHint": "可設定多層排序條件，排序將依照優先級依次執行。變更會即時套用到課程列表中。",
+    "commonSortTag": "常用排序",
+    "commonSortHint": "點擊添加到當前排序",
+    "commonSort": {
+      "byProbability": "依概率",
+      "byAvailable": "依剩餘名額",
+      "byCompulsoryAndLevel": "必修+課程等級"
+    },
+    "addCondition": "新增排序條件",
+    "canAddMore": "(還可新增 {{count}} 個)",
+    "rulesList": "排序規則列表",
+    "defaultSortDescription": "使用預設排序（按課程順序）",
+    "preview": "排序預覽",
+    "priorityTag": "第 {{priority}} 優先",
+    "increasePriority": "提高優先級",
+    "decreasePriority": "降低優先級",
+    "deleteRule": "刪除此排序",
+    "method": "排序方式：",
+    "selectMethod": "選擇排序方式",
+    "direction": "排序方向：",
+    "ascending": "升序",
+    "descending": "降序",
+    "defaultLabel": "預設",
+    "defaultSort": "預設排序",
+    "options": {
+      "default": {
+        "label": "預設順序",
+        "description": "系統原始排序（無升序降序）"
+      },
+      "probability": {
+        "label": "選上概率",
+        "description": "升序：一般概率(低到高)；降序：一般概率(高到低)"
+      },
+      "remaining": {
+        "label": "剩餘名額",
+        "description": "升序：負數(超收)→0→正數(剩餘名額少到多)；降序：正數(剩餘名額多到少)→0→負數(超收)"
+      },
+      "available": {
+        "label": "可選人數",
+        "description": "升序：負數(超收)→0→正數(可選名額少到多)；降序：正數(可選名額多到少)→0→負數(超收)"
+      },
+      "credit": {
+        "label": "學分數",
+        "description": "升序：學分少到多(1→2→3→...)；降序：學分多到少(...→3→2→1)"
+      },
+      "courseLevel": {
+        "label": "課程等級",
+        "description": "升序：大學部→碩士班→碩士專班→博士班；降序：博士班→碩士專班→碩士班→大學部"
+      },
+      "compulsory": {
+        "label": "必修優先",
+        "description": "升序：必修課程→選修課程；降序：選修課程→必修課程"
+      }
+    }
+  },
+  "department": {
+    "title": "系所必/選修",
+    "allGrades": "不分年級",
+    "gradeLabel": "{{grade}} 年級",
+    "allClasses": "不分班",
+    "department": "系所：",
+    "selectDepartment": "選擇系所",
+    "grade": "年級：",
+    "selectGrade": "選擇年級",
+    "class": "班別：",
+    "selectClass": "選擇班別",
+    "type": "類型：",
+    "selectType": "選擇課程類型",
+    "selectAll": "全選 ({{count}})",
+    "selectFilterFirst": "請先篩選條件",
+    "clearSelected": "清除已選 ({{count}})",
+    "allCoursesAlreadySelected": "當前篩選結果中的課程都已被選擇",
+    "batchSelectLimit": "批量選課限制",
+    "batchSelectLimitExceeded": "為防止載入過多課程造成瀏覽器崩潰，單次選擇課程數量不能超過 50 門。請縮小篩選條件或手動選擇課程。",
+    "confirmBatchSelect": "批量選課確認",
+    "batchSelectWarning": "您即將選擇 {{count}} 門課程，這可能會造成大量時間衝突。確定要繼續嗎？",
+    "coursesSelected": "已選擇 {{count}} 門課程",
+    "noSelectedCoursesInFilter": "當前篩選結果中沒有已選課程",
+    "clearSelectedCourses": "清除篩選結果中的已選課程",
+    "clearSelectedWarning": "確定要清除當前篩選結果中的 {{count}} 門已選課程嗎？",
+    "coursesCleared": "已清除 {{count}} 門已選課程",
+    "confirm": "確定",
+    "typeCompulsory": "必修課程",
+    "typeElective": "選修課程",
+    "typeMultipleCompulsory": "多選必修"
+  },
   "simpleFilter": {
     "title": "簡易篩選",
     "simpleMode": "簡易模式",
@@ -295,7 +386,41 @@
     "newLabel": "新增標籤",
     "name": "標籤名稱",
     "bgColor": "背景色",
-    "borderColor": "框線色"
+    "borderColor": "邊框色",
+    "textColor": "文字色",
+    "nameRequired": "請輸入標籤名稱",
+    "namePlaceholder": "請輸入標籤名稱",
+    "bgColorRequired": "請選擇背景色",
+    "borderColorRequired": "請選擇邊框色",
+    "textColorRequired": "請選擇文字色",
+    "colorSettings": "顏色設定",
+    "colorPresets": "常用顏色組合",
+    "applyColorPreset": "應用{{name}}配色",
+    "createLabel": "新增",
+    "updateLabel": "更新",
+    "delete": "刪除",
+    "manage": "標籤管理",
+    "apply": "標籤應用",
+    "applyToCurrentCourseHint": "點擊標籤即可快速應用到當前課程",
+    "selectCourseFirstLong": "請先從課程列表開啟標籤管理",
+    "selectCourseFirst": "請先選擇課程",
+    "alreadyApplied": "已應用標籤「{{name}}」",
+    "applyLabelToCourse": "應用標籤「{{name}}」到課程",
+    "noLabelsCreated": "尚未建立任何標籤",
+    "createFirstLabel": "建立第一個標籤",
+    "currentCourseLabels": "當前課程標籤",
+    "labelCount": "({{count}} 個標籤)",
+    "noCourseLabelsSet": "此課程尚未設定標籤",
+    "colors": {
+      "blue": "藍色",
+      "green": "綠色",
+      "orange": "橙色",
+      "red": "紅色",
+      "purple": "紫色",
+      "cyan": "青色",
+      "yellow": "黃色",
+      "pink": "粉色"
+    }
   },
   "selectedExport": {
     "title": "已選匯出",

--- a/nsysu_selector_helper/src/utils/getSortOptionLabel.ts
+++ b/nsysu_selector_helper/src/utils/getSortOptionLabel.ts
@@ -1,0 +1,34 @@
+import type { AvailableSortOptions } from '@/services';
+import type { TranslationKey } from '@/types';
+
+type TFn = (key: TranslationKey, options?: Record<string, unknown>) => string;
+
+const LABEL_KEYS: Record<AvailableSortOptions, TranslationKey> = {
+  default: 'sort.options.default.label',
+  probability: 'sort.options.probability.label',
+  remaining: 'sort.options.remaining.label',
+  available: 'sort.options.available.label',
+  credit: 'sort.options.credit.label',
+  courseLevel: 'sort.options.courseLevel.label',
+  compulsory: 'sort.options.compulsory.label',
+};
+
+const DESCRIPTION_KEYS: Record<AvailableSortOptions, TranslationKey> = {
+  default: 'sort.options.default.description',
+  probability: 'sort.options.probability.description',
+  remaining: 'sort.options.remaining.description',
+  available: 'sort.options.available.description',
+  credit: 'sort.options.credit.description',
+  courseLevel: 'sort.options.courseLevel.description',
+  compulsory: 'sort.options.compulsory.description',
+};
+
+export const getSortOptionLabel = (
+  key: AvailableSortOptions,
+  t: TFn,
+): string => t(LABEL_KEYS[key]);
+
+export const getSortOptionDescription = (
+  key: AvailableSortOptions,
+  t: TFn,
+): string => t(DESCRIPTION_KEYS[key]);

--- a/nsysu_selector_helper/src/utils/getSortRuleDisplayText.ts
+++ b/nsysu_selector_helper/src/utils/getSortRuleDisplayText.ts
@@ -1,14 +1,17 @@
 import { type SortRule } from '@/services';
-import { DEFAULT_SORT_OPTIONS } from '@/constants';
+import type { TranslationKey } from '@/types';
+import { getSortOptionLabel } from './getSortOptionLabel';
 
-export const getSortRuleDisplayText = (rule: SortRule): string => {
-  const option = DEFAULT_SORT_OPTIONS.find((opt) => opt.key === rule.option);
-  const optionLabel = option?.label || rule.option;
-  const directionLabel = rule.direction === 'asc' ? '升序' : '降序';
+type TFn = (key: TranslationKey, options?: Record<string, unknown>) => string;
 
+export const getSortRuleDisplayText = (rule: SortRule, t: TFn): string => {
   if (rule.option === 'default') {
-    return '預設排序';
+    return t('sort.defaultSort');
   }
+
+  const optionLabel = getSortOptionLabel(rule.option, t);
+  const directionLabel =
+    rule.direction === 'asc' ? t('sort.ascending') : t('sort.descending');
 
   return `${optionLabel} (${directionLabel})`;
 };

--- a/nsysu_selector_helper/src/utils/index.ts
+++ b/nsysu_selector_helper/src/utils/index.ts
@@ -1,3 +1,7 @@
 export { GetProbability } from './getProbability';
 export { getSortRuleDisplayText } from './getSortRuleDisplayText';
 export { getLocalizedCourseName } from './getLocalizedCourseName';
+export {
+  getSortOptionLabel,
+  getSortOptionDescription,
+} from './getSortOptionLabel';


### PR DESCRIPTION
## Summary
Completes the selector panel's translation coverage. Stacks on top of PR #35 (filter UI) so the translation-file edits don't collide.

### Sort panel
- [defaultSortOptions.ts](nsysu_selector_helper/src/constants/defaultSortOptions.ts) now stores only the sort key. A new [getSortOptionLabel / getSortOptionDescription](nsysu_selector_helper/src/utils/getSortOptionLabel.ts) util resolves labels and descriptions through `sort.options.<key>.{label,description}`.
- [getSortRuleDisplayText](nsysu_selector_helper/src/utils/getSortRuleDisplayText.ts) takes `t` and returns translated ascending / descending + option names (the default rule goes through `sort.defaultSort`).
- [CompactSortButton](nsysu_selector_helper/src/components/SelectorPanel/AllCourses/CompactSortButton.tsx), [CourseSortSelector](nsysu_selector_helper/src/components/SelectorPanel/AllCourses/CourseSortSelector.tsx), and [SortRuleItem](nsysu_selector_helper/src/components/SelectorPanel/AllCourses/SortRuleItem.tsx) all consume the new `sort.*` namespace: drawer title, reset popconfirm, common-sort shortcuts, add-condition button with `canAddMore` count, rules list, empty state, preview card, priority tag, direction radio, method selector.
- The sort-option description `；` split now also accepts Latin `;` so the English descriptions wrap correctly.

### Label manager
- [defaultColorPresets.ts](nsysu_selector_helper/src/constants/defaultColorPresets.ts) keys on `nameKey` (`blue`, `green`, …); display name comes from `labels.colors.<key>`.
- [LabelEditModal](nsysu_selector_helper/src/components/Common/Labels/LabelEditModal.tsx): modal title / buttons, every form label and validation message, the color-preset tooltips, and all three color picker labels.
- [LabelEditDrawer](nsysu_selector_helper/src/components/Common/Labels/LabelEditDrawer.tsx): drawer title, apply card, apply / edit / delete menu, tooltip states (with / without `courseId`, already-applied vs available), empty states, the current-course label card + count.

### Department section
- [DepartmentCourses](nsysu_selector_helper/src/components/SelectorPanel/DepartmentCourses.tsx): card title, all four filter rows (label + placeholder), select-all / clear-selected buttons with interpolated counts, every modal/toast (batch-select limit, batch-select confirm, clear-selected confirm, success toasts), and the two bottom toggles reusing `allCourse.showSelectedOnly` / `showConflicts`.
- Grade and class fallback options (`不分年級` / `不分班`) go through `department.allGrades` / `department.allClasses`.
- Compulsory type select gets translated labels at the component boundary without changing `DepartmentCourseService`'s test-covered API.

### Left for follow-up
- `DEFAULT_LABELS` (`候選中課程`, `我的最愛`) is seeded into localStorage as user-mutable data, so I didn't translate it — safe to tackle separately if you want it to render English for fresh English-mode installs.

### Dependency chain
`main` → `i18n/course-name-32` (#34) → `i18n/filter-ui-32` (#35) → **this branch**. GitHub will auto-retarget as each PR lands.

## Test plan
- [x] `yarn tsc -b` passes
- [x] `yarn test` passes (113/113)
- [ ] Manual: English — open the sort drawer, add a common sort preset, change direction, reorder, reset. All strings English.
- [ ] Manual: English — open the label drawer on a course, create a label using a color preset, apply it, remove it. All strings English.
- [ ] Manual: English — on the department section, set each filter, use select-all with >20 and >50 courses to hit both modal paths, then clear. All strings English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)